### PR TITLE
Encode correlation_id as a string

### DIFF
--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -161,7 +161,7 @@ class AmqpEncoder:
         correlation_id = properties.get('correlation_id')
         if correlation_id:
             properties_flag_value |= amqp_constants.FLAG_CORRELATION_ID
-            self.write_octet(correlation_id)
+            self.write_shortstr(correlation_id)
         reply_to = properties.get('reply_to')
         if reply_to:
             properties_flag_value |= amqp_constants.FLAG_REPLY_TO

--- a/aioamqp/tests/test_frame.py
+++ b/aioamqp/tests/test_frame.py
@@ -38,14 +38,24 @@ class EncoderTestCase(unittest.TestCase):
             (b'F\x00\x00\x00\x18\x03barS\x00\x00\x00\x03baz\x03fooS\x00\x00\x00\x03bar',
              b'F\x00\x00\x00\x18\x03fooS\x00\x00\x00\x03bar\x03barS\x00\x00\x00\x03baz'))
 
+    def test_write_message_correlation_id_encode(self):
+        properties = {
+            'delivery_mode': 2,
+            'priority': 0,
+            'correlation_id': '122',
+        }
+        self.encoder.write_message_properties(properties)
+        self.assertEqual(self.encoder.payload.getvalue(),
+                         b'\x14\x00\x02\x03122')
+
     def test_write_message_properties_dont_crash(self):
         properties = {
             'content_type': 'plain/text',
             'content_encoding': 'utf8',
             'headers': {'key': 'value'},
-            'delivery_mode': 42,
+            'delivery_mode': 2,
             'priority': 10,
-            'correlation_id': 122,
+            'correlation_id': '122',
             'reply_to': 'joe',
             'expiration': 'someday',
             'message_id': 'm_id',


### PR DESCRIPTION
`correlation_id` property shoud be encoded as a `shortstr`
