### PR TITLE
Write priority even if it is zero

### DIFF
--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -147,15 +147,15 @@ class AmqpEncoder:
             properties_flag_value |= amqp_constants.FLAG_CONTENT_ENCODING
             self.write_shortstr(content_encoding)
         headers = properties.get('headers')
-        if headers:
+        if headers is not None:
             properties_flag_value |= amqp_constants.FLAG_HEADERS
             self.write_table(headers)
         delivery_mode = properties.get('delivery_mode')
-        if delivery_mode:
+        if delivery_mode is not None:
             properties_flag_value |= amqp_constants.FLAG_DELIVERY_MODE
             self.write_octet(delivery_mode)
         priority = properties.get('priority')
-        if priority:
+        if priority is not None:
             properties_flag_value |= amqp_constants.FLAG_PRIORITY
             self.write_octet(priority)
         correlation_id = properties.get('correlation_id')
@@ -175,7 +175,7 @@ class AmqpEncoder:
             properties_flag_value |= amqp_constants.FLAG_MESSAGE_ID
             self.write_shortstr(message_id)
         timestamp = properties.get('timestamp')
-        if timestamp:
+        if timestamp is not None:
             properties_flag_value |= amqp_constants.FLAG_TIMESTAMP
             self.write_long_long(timestamp)
         type_ = properties.get('type')

--- a/aioamqp/tests/test_frame.py
+++ b/aioamqp/tests/test_frame.py
@@ -58,6 +58,15 @@ class EncoderTestCase(unittest.TestCase):
         self.encoder.write_message_properties(properties)
         self.assertNotEqual(0, len(self.encoder.payload.getvalue()))
 
+    def test_write_message_priority_zero(self):
+        properties = {
+            'delivery_mode': 2,
+            'priority': 0,
+        }
+        self.encoder.write_message_properties(properties)
+        self.assertEqual(self.encoder.payload.getvalue(),
+                         b'\x18\x00\x02\x00')
+
     def test_write_message_properties_raises_on_invalid_property_name(self):
         properties = {
             'invalid': 'coucou',


### PR DESCRIPTION
Existence of int values should be tested comparing with `None` otherwise we miss `0` values
