### PR TITLE
connect() also return transport

### DIFF
--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -23,20 +23,20 @@ def connect(host='localhost', port=5672, login='guest', password='guest',
 
         @kwargs:        Arguments to be given to the protocol_factory instance
 
-        Returns:        an AmqpProtocol instance
+        Returns:        a tuple (transport, protocol) of an AmqpProtocol instance
     """
     if kwargs:
-        _transport, protocol = yield from asyncio.get_event_loop().create_connection(
+        transport, protocol = yield from asyncio.get_event_loop().create_connection(
         lambda: protocol_factory(**kwargs), host, port)
 
     else:
-        _transport, protocol = yield from asyncio.get_event_loop().create_connection(
+        transport, protocol = yield from asyncio.get_event_loop().create_connection(
         protocol_factory, host, port)
 
     yield from protocol.start_connection(host, port, login, password, virtualhost, ssl=ssl,
         login_method=login_method, insist=insist)
 
-    return protocol
+    return (transport, protocol)
 
 
 @asyncio.coroutine
@@ -48,7 +48,7 @@ def from_url(url, login_method='AMQPLAIN', insist=False, protocol_factory=AmqpPr
     if url.scheme not in ('amqp', 'amqps'):
         raise ValueError('Invalid protocol %s, valid protocols are amqp or amqps' % url.scheme)
 
-    protocol = yield from connect(
+    transport, protocol = yield from connect(
         host=url.hostname or 'localhost',
         port=url.port or 5672,
         login=url.username or 'guest',

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -27,8 +27,8 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
         super().tearDown()
 
     def test_connect(self):
-        proto = self.loop.run_until_complete(amqp_connect())
-        self.assertTrue(proto.is_open)
+        transport, protocol = self.loop.run_until_complete(amqp_connect())
+        self.assertTrue(protocol.is_open)
 
     def test_connection_unexistant_vhost(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -131,8 +131,8 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         yield from self.channel.basic_consume("q", no_wait=False, callback=self.callback)
         # create an other amqp connection
 
-        amqp2 = yield from self.create_amqp()
-        channel = yield from self.create_channel(amqp=amqp2)
+        transport, protocol = yield from self.create_amqp()
+        channel = yield from self.create_channel(amqp=protocol)
         # assert that this connection cannot connect to the queue
         with self.assertRaises(exceptions.ChannelClosed):
             yield from channel.basic_consume("q", no_wait=False, callback=self.callback)
@@ -145,8 +145,8 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # consume it
         yield from self.channel.basic_consume('q', no_wait=False, callback=self.callback)
         # create an other amqp connection
-        amqp2 = yield from self.create_amqp()
-        channel = yield from self.create_channel(amqp=amqp2)
+        transport, protocol = yield from self.create_amqp()
+        channel = yield from self.create_channel(amqp=protocol)
         # assert that this connection can connect to the queue
         yield from channel.basic_consume('q', no_wait=False, callback=self.callback)
 

--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -102,8 +102,8 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
 
         @asyncio.coroutine
         def go():
-            amqp = yield from self.create_amqp()
-            self.amqps.append(amqp)
+            transport, protocol = yield from self.create_amqp()
+            self.amqps.append(protocol)
             channel = yield from self.create_channel()
             self.channels.append(channel)
         self.loop.run_until_complete(go())
@@ -334,7 +334,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
         def protocol_factory(*args, **kw):
             return ProxyAmqpProtocol(self, *args, **kw)
         vhost = vhost or self.vhost
-        amqp = yield from aioamqp_connect(host=self.host, port=self.port, virtualhost=vhost,
+        transport, protocol = yield from aioamqp_connect(host=self.host, port=self.port, virtualhost=vhost,
             protocol_factory=protocol_factory)
-        self.amqps.append(amqp)
-        return amqp
+        self.amqps.append(protocol)
+        return transport, protocol

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,7 +25,7 @@ Starting a connection to AMQP really mean instanciate a new asyncio Protocol sub
     @asyncio.coroutine
     def connect():
         try:
-            protocol = yield from aioamqp.connect()  # use default parameters
+            transport, protocol = yield from aioamqp.connect()  # use default parameters
         except aioamqp.AmqpClosedConnection:
             print("closed connections")
             return
@@ -34,7 +34,7 @@ Starting a connection to AMQP really mean instanciate a new asyncio Protocol sub
         yield from asyncio.sleep(1)
 
         print("close connection")
-        yield from protocol.close()
+        yield from transport.close()
 
     asyncio.get_event_loop().run_until_complete(connect())
 

--- a/examples/emit_log.py
+++ b/examples/emit_log.py
@@ -15,7 +15,7 @@ import sys
 @asyncio.coroutine
 def exchange_routing():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return
@@ -29,7 +29,7 @@ def exchange_routing():
     yield from channel.publish(message, exchange_name=exchange_name, routing_key='')
     print(" [x] Sent %r" % (message,))
 
-    yield from protocol.close()
+    yield from transport.close()
 
 
 asyncio.get_event_loop().run_until_complete(exchange_routing())

--- a/examples/emit_log_direct.py
+++ b/examples/emit_log_direct.py
@@ -14,7 +14,7 @@ import sys
 @asyncio.coroutine
 def exchange_routing():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return
@@ -30,7 +30,7 @@ def exchange_routing():
         message, exchange_name=exchange_name, routing_key=severity)
     print(" [x] Sent %r" % (message,))
 
-    yield from protocol.close()
+    yield from transport.close()
 
 
 asyncio.get_event_loop().run_until_complete(exchange_routing())

--- a/examples/emit_log_topic.py
+++ b/examples/emit_log_topic.py
@@ -14,7 +14,7 @@ import sys
 @asyncio.coroutine
 def exchange_routing():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return
@@ -30,7 +30,7 @@ def exchange_routing():
         message, exchange_name=exchange_name, routing_key=routing_key)
     print(" [x] Sent %r" % (message,))
 
-    yield from protocol.close()
+    yield from transport.close()
 
 
 asyncio.get_event_loop().run_until_complete(exchange_routing())

--- a/examples/new_task.py
+++ b/examples/new_task.py
@@ -9,7 +9,7 @@ import sys
 @asyncio.coroutine
 def exchange_routing():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return
@@ -27,7 +27,7 @@ def exchange_routing():
     yield from channel.publish("Message ", '', queue_name, properties=message_properties)
     print(" [x] Sent %r" % (message,))
 
-    yield from protocol.close()
+    yield from transport.close()
 
 
 asyncio.get_event_loop().run_until_complete(exchange_routing())

--- a/examples/publisher.py
+++ b/examples/publisher.py
@@ -11,7 +11,7 @@ import aioamqp
 @asyncio.coroutine
 def produce():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -10,7 +10,7 @@ def callback(consumer_tag, deliver_tag, message):
 @asyncio.coroutine
 def receive():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return

--- a/examples/receive_log.py
+++ b/examples/receive_log.py
@@ -20,7 +20,7 @@ def callback(consumer_tag, deliver_tag, message):
 @asyncio.coroutine
 def receive_log():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return

--- a/examples/receive_log_direct.py
+++ b/examples/receive_log_direct.py
@@ -20,7 +20,7 @@ def callback(consumer_tag, delivery_tag, message):
 @asyncio.coroutine
 def receive_log():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return

--- a/examples/receive_log_topic.py
+++ b/examples/receive_log_topic.py
@@ -20,7 +20,7 @@ def callback(consumer_tag, delivery_tag, message):
 @asyncio.coroutine
 def receive_log():
     try:
-        protocol = yield from aioamqp.connect('localhost', 5672)
+        transport, protocol = yield from aioamqp.connect('localhost', 5672)
     except aioamqp.AmqpClosedConnection:
         print("closed connections")
         return


### PR DESCRIPTION
Connect() now return (transport, protocol) instead of protocol only.
This will allow us to use transport to close connection properly.
