### PR TITLE
Remove 'policy' argument from list_queues in tests.

### DIFF
--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -234,7 +234,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
         if vhost is None:
             vhost = self.vhost
         info = ['name', 'durable', 'auto_delete',
-            'arguments', 'policy', 'pid', 'owner_pid', 'exclusive_consumer_pid',
+            'arguments',  'pid', 'owner_pid', 'exclusive_consumer_pid',
             'exclusive_consumer_tag', 'messages_ready', 'messages_unacknowledged', 'messages',
             'consumers', 'memory', 'slave_pids', 'synchronised_slave_pids']
         return (yield from self.rabbitctl_list('list_queues', info, vhost=vhost,


### PR DESCRIPTION
RabbitMQ version 2.7.1 doesn't seem to support the 'policy' argument with `rabbitmqctl list_queues` breaking the test suite.

EDIT:
```
$ sudo rabbitmqctl list_queues policy
Listing queues ...
Error: {bad_argument,policy}
```