### PR TITLE
Allow partially applied coroutines to be used for callbacks

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -10,6 +10,7 @@ import io
 from . import constants as amqp_constants
 from . import frame as amqp_frame
 from . import exceptions
+from . import utils 
 
 logger = logging.getLogger(__name__)
 
@@ -530,7 +531,7 @@ class Channel:
         if arguments is None:
             arguments = {}
 
-        if callback is None or not asyncio.iscoroutinefunction(callback):
+        if callback is None or not utils.iscoroutinefunction(callback):
             raise exceptions.ConfigurationError("basic_consume requires a coroutine callback")
 
         frame = amqp_frame.AmqpRequest(

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -10,7 +10,7 @@ from . import constants as amqp_constants
 from . import frame as amqp_frame
 from . import exceptions
 from . import version
-
+from . import utils
 
 logger = logging.getLogger(__name__)
 
@@ -245,7 +245,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         yield from self._close_channels(reply_code, reply_text)
 
         if self._on_error_callback:
-            if asyncio.iscoroutinefunction(self._on_error_callback):
+            if utils.iscoroutinefunction(self._on_error_callback):
                 yield from self._on_error_callback(exceptions.ChannelClosed(reply_code, reply_text))
             else:
                 self._on_error_callback(exceptions.ChannelClosed(reply_code, reply_text))

--- a/aioamqp/utils.py
+++ b/aioamqp/utils.py
@@ -1,0 +1,8 @@
+import asyncio
+
+def iscoroutinefunction(func):
+    # Workaround for curried and partial functions.
+    if asyncio.iscoroutinefunction(func):
+        return True
+
+    return asyncio.iscoroutinefunction(getattr(func, 'func', None))


### PR DESCRIPTION
It is often useful to pass additional arguments to to callbacks. The recommended way is by using `functools.partial`. However the built in `asyncio. iscoroutinefunction` does not recognize coroutines wrapped in `partial`. This commit includes a workaround and a test for that.