### PR TITLE
Add support for receive properties tags in basic_consume() callbacks.

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -585,7 +585,12 @@ class Channel:
         if event:
             yield from event.wait()
             del self._ctag_events[consumer_tag]
-        yield from callback(consumer_tag, deliver_tag, buffer.getvalue())
+        try:
+            yield from callback(consumer_tag, deliver_tag, buffer.getvalue(), content_header_frame.properties)
+        except TypeError as exc:
+            if 'positional arguments' not in str(exc):
+                raise
+            yield from callback(consumer_tag, deliver_tag, buffer.getvalue())
 
     @asyncio.coroutine
     def server_basic_cancel(self, frame):

--- a/aioamqp/tests/test_basic.py
+++ b/aioamqp/tests/test_basic.py
@@ -47,7 +47,7 @@ class BasicCancelTestCase(testcase.RabbitTestCase, unittest.TestCase):
     def test_basic_cancel(self):
 
         @asyncio.coroutine
-        def callback(ctag, dtag, message):
+        def callback(ctag, dtag, message, properties):
             pass
 
         queue_name = 'queue_name'
@@ -124,11 +124,11 @@ class BasicDeliveryTestCase(testcase.RabbitTestCase, unittest.TestCase):
         qfuture = asyncio.Future()
 
         @asyncio.coroutine
-        def qcallback(consumer_tag, deliver_tag, message):
-            qfuture.set_result((consumer_tag, deliver_tag, message))
+        def qcallback(consumer_tag, deliver_tag, message, properties):
+            qfuture.set_result((consumer_tag, deliver_tag, message, properties))
 
         yield from self.channel.basic_consume(queue_name, callback=qcallback)
-        ctag, dtag, message = yield from qfuture
+        ctag, dtag, message, properties = yield from qfuture
 
         yield from qfuture
         yield from self.channel.basic_client_ack(dtag)
@@ -146,10 +146,10 @@ class BasicDeliveryTestCase(testcase.RabbitTestCase, unittest.TestCase):
         qfuture = asyncio.Future()
 
         @asyncio.coroutine
-        def qcallback(consumer_tag, deliver_tag, message):
-            qfuture.set_result((consumer_tag, deliver_tag, message))
+        def qcallback(consumer_tag, deliver_tag, message, properties):
+            qfuture.set_result((consumer_tag, deliver_tag, message, properties))
 
         yield from self.channel.basic_consume(queue_name, callback=qcallback)
-        ctag, dtag, message = yield from qfuture
+        ctag, dtag, message, properties = yield from qfuture
 
         yield from self.channel.basic_reject(dtag)

--- a/aioamqp/tests/test_close.py
+++ b/aioamqp/tests/test_close.py
@@ -15,8 +15,8 @@ class CloseTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.consume_future = asyncio.Future()
 
     @asyncio.coroutine
-    def callback(self, consumer_tag, deliver_tag, message):
-        self.consume_future.set_result((consumer_tag, deliver_tag, message))
+    def callback(self, consumer_tag, deliver_tag, message, properties):
+        self.consume_future.set_result((consumer_tag, deliver_tag, message, properties))
 
     @asyncio.coroutine
     def get_callback_result(self):

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -17,7 +17,7 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.consume_future = asyncio.Future()
 
     @asyncio.coroutine
-    def callback(self, consumer_tag, deliver_tag, message):
+    def callback(self, consumer_tag, deliver_tag, message, properties):
         self.consume_future.set_result((consumer_tag, deliver_tag, message))
 
     @asyncio.coroutine

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -66,7 +66,7 @@ When consuming message, you connect to the same queue you previously created::
     import aioamqp
 
     @asyncio.coroutine
-    def callback(consumer_tag, delivery_tag, message):
+    def callback(consumer_tag, delivery_tag, message, properties):
         print(message)
 
     channel = yield from protocol.channel()

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -4,7 +4,7 @@ import asyncio
 import aioamqp
 
 @asyncio.coroutine
-def callback(consumer_tag, deliver_tag, message):
+def callback(consumer_tag, deliver_tag, message, properties):
     print(message)
 
 @asyncio.coroutine

--- a/examples/receive_log.py
+++ b/examples/receive_log.py
@@ -13,7 +13,7 @@ import random
 
 
 @asyncio.coroutine
-def callback(consumer_tag, deliver_tag, message):
+def callback(consumer_tag, deliver_tag, message, properties):
     print(message)
 
 

--- a/examples/receive_log_direct.py
+++ b/examples/receive_log_direct.py
@@ -14,7 +14,7 @@ import sys
 
 
 @asyncio.coroutine
-def callback(consumer_tag, delivery_tag, message):
+def callback(consumer_tag, delivery_tag, message, properties):
     print("consumer {} recved {} ({})".format(consumer_tag, message, delivery_tag))
 
 @asyncio.coroutine

--- a/examples/receive_log_topic.py
+++ b/examples/receive_log_topic.py
@@ -14,7 +14,7 @@ import sys
 
 
 @asyncio.coroutine
-def callback(consumer_tag, delivery_tag, message):
+def callback(consumer_tag, delivery_tag, message, properties):
     print("consumer {} recved {} ({})".format(consumer_tag, message, delivery_tag))
 
 @asyncio.coroutine


### PR DESCRIPTION
Currently aioamqp allows to set properties of sending messages via channel.basic_publish(properties={}), but no any way to get such properties from received messages.
This properties is used in pika RPC examples from RabbitMQ site (https://www.rabbitmq.com/tutorials/tutorial-six-python.html).

My implementation note: because consume callbacks uses only positional arguments, I have added 'properties' as last parameter of callback. For backward compatibility callback execution wrapped in try/except block and tries to exec callback function without new argument on exception.
