### PR TITLE
Missing possibility to pass keyword arguments to protocol_factory in from_url

### DIFF
--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -62,7 +62,7 @@ def connect(host='localhost', port=None, login='guest', password='guest',
 @asyncio.coroutine
 def from_url(
         url, login_method='AMQPLAIN', insist=False, protocol_factory=AmqpProtocol, *,
-        verify_ssl=True):
+        verify_ssl=True, **kwargs):
     """ Connect to the AMQP using a single url parameter and return the client.
 
         For instance:
@@ -86,5 +86,6 @@ def from_url(
         login_method=login_method,
         insist=insist,
         protocol_factory=protocol_factory,
-        verify_ssl=verify_ssl)
+        verify_ssl=verify_ssl,
+        **kwargs)
     return transport, protocol

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Next version (not yet released)
 -------------------------------
 
+ * Add possibility to pass extra keyword arguments to protocol_factory when from_url is used to create a connection
  * Add SSL support.
 
 


### PR DESCRIPTION
As title says there is no way to pass extra kwargs to protocol_factory constructor when from_url is used to create connection.