### PR TITLE
fix testcase, add loop param

### DIFF
--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -13,7 +13,7 @@ from .version import __packagename__
 @asyncio.coroutine
 def connect(host='localhost', port=None, login='guest', password='guest',
             virtualhost='/', ssl=False, login_method='AMQPLAIN', insist=False,
-            protocol_factory=AmqpProtocol, *, verify_ssl=True, **kwargs):
+            protocol_factory=AmqpProtocol, *, verify_ssl=True, loop=None, **kwargs):
     """Convenient method to connect to an AMQP broker
 
         @host:          the host to connect to
@@ -30,10 +30,9 @@ def connect(host='localhost', port=None, login='guest', password='guest',
 
         Returns:        a tuple (transport, protocol) of an AmqpProtocol instance
     """
-    if kwargs:
-        factory = lambda: protocol_factory(**kwargs)
-    else:
-        factory = protocol_factory
+    if loop is None:
+        loop = asyncio.get_event_loop()
+    factory = lambda: protocol_factory(loop=loop, **kwargs)
 
     create_connection_kwargs = {}
 
@@ -52,7 +51,7 @@ def connect(host='localhost', port=None, login='guest', password='guest',
         else:
             port = 5672
 
-    transport, protocol = yield from asyncio.get_event_loop().create_connection(
+    transport, protocol = yield from loop.create_connection(
         factory, host, port, **create_connection_kwargs
     )
 

--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -25,7 +25,9 @@ def connect(host='localhost', port=None, login='guest', password='guest',
         @verify_ssl:    Verify server's SSL certificate (True by default)
         @login_method:  AMQP auth method
         @insist:        Insist on connecting to a server
-        @loop:          optionally set the event loop to use.
+        @protocol_factory:
+                        Factory to use, if you need to subclass AmqpProtocol
+        @loop:          Set the event loop to use
 
         @kwargs:        Arguments to be given to the protocol_factory instance
 
@@ -71,6 +73,14 @@ def from_url(
         For instance:
 
             amqp://user:password@hostname:port/vhost
+
+        @insist:        Insist on connecting to a server
+        @protocol_factory:
+                        Factory to use, if you need to subclass AmqpProtocol
+        @verify_ssl:    Verify server's SSL certificate (True by default)
+        @loop:          optionally set the event loop to use.
+
+        @kwargs:        Arguments to be given to the protocol_factory instance
 
         Returns:        a tuple (transport, protocol) of an AmqpProtocol instance
     """

--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -25,6 +25,7 @@ def connect(host='localhost', port=None, login='guest', password='guest',
         @verify_ssl:    Verify server's SSL certificate (True by default)
         @login_method:  AMQP auth method
         @insist:        Insist on connecting to a server
+        @loop:          optionally set the event loop to use.
 
         @kwargs:        Arguments to be given to the protocol_factory instance
 

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -43,7 +43,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         self.reader = None
         self.writer = None
         self.worker = None
-        self.hearbeat = None
+        self.heartbeat = None
         self.channels = {}
         self.server_frame_max = None
         self.server_channel_max = None
@@ -125,7 +125,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         tune_ok = {
             'channel_max': self.server_channel_max,
             'frame_max': self.server_frame_max,
-            'heartbeat': self.hearbeat,
+            'heartbeat': self.heartbeat,
         }
         # "tune" the connexion with max channel, max frame, heartbeat
         yield from self.tune_ok(**tune_ok)
@@ -169,7 +169,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             #print("frame.channel {} class_id {}".format(frame.channel, frame.class_id))
 
         if frame.frame_type == amqp_constants.TYPE_HEARTBEAT:
-            yield from self.reply_to_hearbeat(frame)
+            yield from self.reply_to_heartbeat(frame)
             return
 
         if frame.channel is not 0:
@@ -229,7 +229,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
                 logger.exception('error on dispatch')
 
     @asyncio.coroutine
-    def reply_to_hearbeat(self, frame):
+    def reply_to_heartbeat(self, frame):
         logger.debug("replyin' to heartbeat")
         frame = amqp_frame.AmqpRequest(self.writer, amqp_constants.TYPE_HEARTBEAT, 0)
         request = amqp_frame.AmqpEncoder()
@@ -278,7 +278,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         decoder = amqp_frame.AmqpDecoder(frame.payload)
         self.server_channel_max = decoder.read_short()
         self.server_frame_max = decoder.read_long()
-        self.hearbeat = decoder.read_short()
+        self.heartbeat = decoder.read_short()
 
     @asyncio.coroutine
     def tune_ok(self, channel_max, frame_max, heartbeat):

--- a/aioamqp/tests/test_basic.py
+++ b/aioamqp/tests/test_basic.py
@@ -60,7 +60,7 @@ class BasicCancelTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
         result = yield from self.channel.publish("payload", exchange_name, routing_key='')
 
-        yield from asyncio.sleep(5)
+        yield from asyncio.sleep(5, loop=self.loop)
 
         result = yield from self.channel.queue_declare(queue_name, passive=True)
         self.assertEqual(result['message_count'], 1)
@@ -121,7 +121,7 @@ class BasicDeliveryTestCase(testcase.RabbitTestCase, unittest.TestCase):
         yield from self.channel.queue_bind(queue_name, exchange_name, routing_key=routing_key)
         yield from self.channel.publish("payload", exchange_name, queue_name)
 
-        qfuture = asyncio.Future()
+        qfuture = asyncio.Future(loop=self.loop)
 
         @asyncio.coroutine
         def qcallback(body, envelope, properties):
@@ -143,7 +143,7 @@ class BasicDeliveryTestCase(testcase.RabbitTestCase, unittest.TestCase):
         yield from self.channel.queue_bind(queue_name, exchange_name, routing_key=routing_key)
         yield from self.channel.publish("payload", exchange_name, queue_name)
 
-        qfuture = asyncio.Future()
+        qfuture = asyncio.Future(loop=self.loop)
 
         @asyncio.coroutine
         def qcallback(body, envelope, properties):

--- a/aioamqp/tests/test_close.py
+++ b/aioamqp/tests/test_close.py
@@ -12,7 +12,7 @@ class CloseTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.consume_future = asyncio.Future()
+        self.consume_future = asyncio.Future(loop=self.loop)
 
     @asyncio.coroutine
     def callback(self, body, envelope, properties):
@@ -22,7 +22,7 @@ class CloseTestCase(testcase.RabbitTestCase, unittest.TestCase):
     def get_callback_result(self):
         yield from self.consume_future
         result = self.consume_future.result()
-        self.consume_future = asyncio.Future()
+        self.consume_future = asyncio.Future(loop=self.loop)
         return result
 
     @testing.coroutine

--- a/aioamqp/tests/test_connect.py
+++ b/aioamqp/tests/test_connect.py
@@ -11,7 +11,7 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_connect(self):
-        transport, proto = yield from connect(vhost=self.vhost)
+        transport, proto = yield from connect(vhost=self.vhost, loop=self.loop)
         self.assertTrue(proto.is_open)
         self.assertIsNotNone(proto.server_properties)
 

--- a/aioamqp/tests/test_connection_lost.py
+++ b/aioamqp/tests/test_connection_lost.py
@@ -33,7 +33,7 @@ class ConnectionLostTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertTrue(amqp.is_open)
         self.assertTrue(channel.is_open)
         transport.close()  # this should have the same effect as the tcp connection being lost
-        yield from asyncio.sleep(1)
+        yield from asyncio.sleep(1, loop=self.loop)
         self.assertFalse(amqp.is_open)
         self.assertFalse(channel.is_open)
         yield from amqp.close()

--- a/aioamqp/tests/test_consume.py
+++ b/aioamqp/tests/test_consume.py
@@ -15,7 +15,7 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.consume_future = asyncio.Future()
+        self.consume_future = asyncio.Future(loop=self.loop)
 
     @asyncio.coroutine
     def callback(self, body, envelope, properties):
@@ -25,7 +25,7 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
     def get_callback_result(self):
         yield from self.consume_future
         result = self.consume_future.result()
-        self.consume_future = asyncio.Future()
+        self.consume_future = asyncio.Future(loop=self.loop)
         return result
 
 
@@ -49,7 +49,7 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertIn("q", queues)
         self.assertEqual(1, queues["q"]['messages'])
 
-        yield from asyncio.sleep(2)
+        yield from asyncio.sleep(2, loop=self.loop)
         # start consume
         with self.assertRaises(exceptions.ConfigurationError):
             yield from channel.basic_consume("q", callback=badcallback)
@@ -72,11 +72,11 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertIn("q", queues)
         self.assertEqual(1, queues["q"]['messages'])
 
-        yield from asyncio.sleep(2)
+        yield from asyncio.sleep(2, loop=self.loop)
         # start consume
         yield from channel.basic_consume("q", callback=self.callback)
         # required ?
-        yield from asyncio.sleep(2)
+        yield from asyncio.sleep(2, loop=self.loop)
 
         self.assertTrue(self.consume_future.done())
         # get one
@@ -109,7 +109,7 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # start consume
         yield from channel.basic_consume("q", callback=self.callback)
 
-        yield from asyncio.sleep(1)
+        yield from asyncio.sleep(1, loop=self.loop)
 
         self.assertTrue(self.consume_future.done())
         # get one
@@ -130,13 +130,13 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # get a different channel
         channel = yield from self.create_channel()
 
-        q1_future = asyncio.Future()
+        q1_future = asyncio.Future(loop=self.loop)
 
         @asyncio.coroutine
         def q1_callback(body, envelope, properties):
             q1_future.set_result((body, envelope, properties))
 
-        q2_future = asyncio.Future()
+        q2_future = asyncio.Future(loop=self.loop)
 
         @asyncio.coroutine
         def q2_callback(body, envelope, properties):
@@ -195,7 +195,7 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
         queues = self.list_queues()
         self.assertIn("q", queues)
         self.assertEqual(1, queues["q"]['messages'])
-        sync_future = asyncio.Future()
+        sync_future = asyncio.Future(loop=self.loop)
 
         @asyncio.coroutine
         def callback(body, envelope, properties):

--- a/aioamqp/tests/test_properties.py
+++ b/aioamqp/tests/test_properties.py
@@ -66,13 +66,13 @@ class ReplyTestCase(testcase.RabbitTestCase, unittest.TestCase):
         exchange_name = 'exchange_name'
         server_routing_key = 'reply_test'
 
-        server_future = asyncio.Future()
+        server_future = asyncio.Future(loop=self.loop)
         yield from self._server(server_future, exchange_name, server_routing_key)
 
         correlation_id = 'secret correlation id'
         client_routing_key = 'secret_client_key'
 
-        client_future = asyncio.Future()
+        client_future = asyncio.Future(loop=self.loop)
         yield from self._client(
             client_future, exchange_name, server_routing_key, correlation_id, client_routing_key)
 

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -27,13 +27,14 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
         super().tearDown()
 
     def test_connect(self):
-        transport, protocol = self.loop.run_until_complete(amqp_connect())
+        transport, protocol = self.loop.run_until_complete(amqp_connect(loop=self.loop))
         self.assertTrue(protocol.is_open)
 
     def test_connect_products_info(self):
         transport, protocol = self.loop.run_until_complete(amqp_connect(
             product='test_product',
             product_version='0.1.0',
+            loop=self.loop,
         ))
 
         self.assertEqual(protocol.product, 'test_product')
@@ -41,11 +42,11 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
 
     def test_connection_unexistant_vhost(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):
-            self.loop.run_until_complete(amqp_connect(virtualhost='/unexistant'))
+            self.loop.run_until_complete(amqp_connect(virtualhost='/unexistant', loop=self.loop))
 
     def test_connection_wrong_login_password(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):
-            self.loop.run_until_complete(amqp_connect(login='wrong', password='wrong'))
+            self.loop.run_until_complete(amqp_connect(login='wrong', password='wrong', loop=self.loop))
 
     @testing.coroutine
     def test_connection_from_url(self):
@@ -54,7 +55,7 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
             def func(*x,**y):
                 return 1,2
             connect.side_effect = func
-            yield from amqp_from_url('amqp://tom:pass@example.com:7777/myvhost')
+            yield from amqp_from_url('amqp://tom:pass@example.com:7777/myvhost', loop=self.loop)
             connect.assert_called_once_with(
                 insist=False,
                 password='pass',
@@ -66,6 +67,7 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
                 virtualhost='myvhost',
                 port=7777,
                 verify_ssl=True,
+                loop=self.loop,
             )
 
     @testing.coroutine

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -47,8 +47,13 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
         with self.assertRaises(exceptions.AmqpClosedConnection):
             self.loop.run_until_complete(amqp_connect(login='wrong', password='wrong'))
 
+    @testing.coroutine
     def test_connection_from_url(self):
         with mock.patch('aioamqp.connect') as connect:
+            @asyncio.coroutine
+            def func(*x,**y):
+                return 1,2
+            connect.side_effect = func
             yield from amqp_from_url('amqp://tom:pass@example.com:7777/myvhost')
             connect.assert_called_once_with(
                 insist=False,
@@ -59,7 +64,8 @@ class ProtocolTestCase(unittest.TestCase, testing.AsyncioTestCaseMixin):
                 host='example.com',
                 protocol_factory=protocol.AmqpProtocol,
                 virtualhost='myvhost',
-                port=7777
+                port=7777,
+                verify_ssl=True,
             )
 
     @testing.coroutine

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -14,7 +14,7 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.consume_future = asyncio.Future()
+        self.consume_future = asyncio.Future(loop=self.loop)
 
     @asyncio.coroutine
     def callback(self, body, envelope, properties):
@@ -24,7 +24,7 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
     def get_callback_result(self):
         yield from self.consume_future
         result = self.consume_future.result()
-        self.consume_future = asyncio.Future()
+        self.consume_future = asyncio.Future(loop=self.loop)
         return result
 
     @testing.coroutine

--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -286,7 +286,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
             return ProxyAmqpProtocol(self, *args, **kw)
         vhost = vhost or self.vhost
         transport, protocol = yield from aioamqp_connect(host=self.host, port=self.port, virtualhost=vhost,
-            protocol_factory=protocol_factory)
+            protocol_factory=protocol_factory, loop=self.loop)
         self.amqps.append(protocol)
         self.transports.append(transport)
         return transport, protocol

--- a/aioamqp/tests/testing.py
+++ b/aioamqp/tests/testing.py
@@ -38,7 +38,7 @@ def coroutine(func):
         handler.messages = []
         coro = asyncio.coroutine(func)
         timeout_ = getattr(func, '__timeout__', self.__timeout__)
-        self.loop.run_until_complete(asyncio.wait_for(coro(self), timeout=timeout_))
+        self.loop.run_until_complete(asyncio.wait_for(coro(self), timeout=timeout_, loop=self.loop))
         if len(handler.messages) != 0:
             raise AsyncioErrors(handler.messages)
     return wrapper

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,6 +41,8 @@ Starting a connection to AMQP really mean instanciate a new asyncio Protocol sub
 
 In this example, we just use the method "start_connection" to begin a communication with the server, which deals with credentials and connection tunning.
 
+If you're not using the default event loop (e.g. because you're using
+aioamqp from a different thread), call aioamqp.connect(loop=your_loop).
 
 Handling errors
 ---------------


### PR DESCRIPTION
Two changes:
* a testcase had a missing @testing.coroutine decorator.
* add a loop parameter so that it's possible to run aioamqp in another thread.