### PR TITLE
channel: ensure we don't mess with waiter when the connection is closing

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -60,6 +60,8 @@ class Channel:
 
     def connection_closed(self, server_code=None, server_reason=None, exception=None):
         for future in self._futures.values():
+            if future.done():
+                continue
             if exception is None:
                 kwargs = {}
                 if server_code is not None:


### PR DESCRIPTION
When the connection is closing, the current code tries to stop all the waiters (on all previous command sent to the server).

