### PR TITLE
Add routing_key parameter to channel.queue_bind example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -185,5 +185,5 @@ You can bind an exchange to a queue::
     channel = yield from protocol.channel()
     exchange = yield from channel.exchange_declare(exchange_name="my_exchange", type_name='fanout')
     yield from channel.queue_declare("my_queue")
-    yield from channel.queue_bind("my_queue", "my_exchange")
+    yield from channel.queue_bind("my_queue", "my_exchange", "my_routing_key")
 


### PR DESCRIPTION
``channel.queue_bind`` requires a ``routing_key`` parameter. The
existing example in the API documentation does not pass a routing key to
the function call (causing the call to fail), so this change updates the
example to include one.