### PR TITLE
Drop channel instance after channel is closed

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -222,6 +222,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         channel_id
         """
         self.channels_ids_free.add(channel_id)
+        self.channels.pop(channel_id)
 
     @property
     def channels_ids_count(self):

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -246,7 +246,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             else:
                 self._on_error_callback(exceptions.ChannelClosed(exception))
 
-        for channel in self.channels.values():
+        for channel in self.channels.copy().values():
             channel.connection_closed(reply_code, reply_text, exception)
 
     @asyncio.coroutine


### PR DESCRIPTION
This means we avoid calling 'channel.connection_closed' on already closed channels.