### PR TITLE
Send channel-close-ok in response to server channel-close messages

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -167,7 +167,17 @@ class Channel:
         self._close_channel()
 
     @asyncio.coroutine
+    def _send_channel_close_ok(self):
+        frame = amqp_frame.AmqpRequest(
+            self.protocol.writer, amqp_constants.TYPE_METHOD, self.channel_id)
+        frame.declare_method(
+            amqp_constants.CLASS_CHANNEL, amqp_constants.CHANNEL_CLOSE_OK)
+        request = amqp_frame.AmqpEncoder()
+        yield from self._write_frame(frame, request, no_wait=False)
+
+    @asyncio.coroutine
     def server_channel_close(self, frame):
+        yield from self._send_channel_close_ok()
         results = {
             'reply_code': frame.payload_decoder.read_short(),
             'reply_text': frame.payload_decoder.read_shortstr(),

--- a/aioamqp/tests/test_channel.py
+++ b/aioamqp/tests/test_channel.py
@@ -29,6 +29,16 @@ class ChannelTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertFalse(channel.is_open)
 
     @testing.coroutine
+    def test_server_initiated_close(self):
+        channel = yield from self.amqp.channel()
+        try:
+            yield from channel.basic_get(queue_name='non-existant')
+        except exceptions.ChannelClosed as e:
+            self.assertEqual(e.code, 404)
+        self.assertFalse(channel.is_open)
+        channel = yield from self.amqp.channel()
+
+    @testing.coroutine
     def test_alreadyclosed_channel(self):
         channel = yield from self.amqp.channel()
         result = yield from channel.close()


### PR DESCRIPTION
This helps around channel reuse in the case of a server initiated close.
For instance trying to consume from a non-existent queue.
The current handler returns the channel_id to the pool without sending the channel_close_ok.
The channel cannot be used (at least with rabbitmq) as the broker is waiting for that response.