### PR TITLE
Wrong calculating of chunk size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ docs/_build/
 
 # editor stuffs
 *.swp
+.idea

--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -547,6 +547,8 @@ class Channel:
         assert len(payload) != 0, "Payload cannot be empty"
         if not self.is_open:
             raise exceptions.ChannelClosed()
+        if isinstance(payload, str):
+            payload = payload.encode()
 
         method_frame = amqp_frame.AmqpRequest(
             self.protocol.writer, amqp_constants.TYPE_METHOD, self.channel_id)
@@ -578,10 +580,7 @@ class Channel:
                 self.protocol.writer, amqp_constants.TYPE_BODY, self.channel_id)
             content_frame.declare_class(amqp_constants.CLASS_BASIC)
             encoder = amqp_frame.AmqpEncoder()
-            if isinstance(chunk, str):
-                encoder.payload.write(chunk.encode())
-            else:
-                encoder.payload.write(chunk)
+            encoder.payload.write(chunk)
             content_frame.write_frame(encoder)
 
         yield from self.protocol.writer.drain()
@@ -893,6 +892,8 @@ class Channel:
         assert len(payload) != 0, "Payload cannot be empty"
         if not self.is_open:
             raise exceptions.ChannelClosed()
+        if isinstance(payload, str):
+            payload = payload.encode()
 
         if self.publisher_confirms:
             delivery_tag = next(self.delivery_tag_iter)
@@ -928,10 +929,7 @@ class Channel:
                 self.protocol.writer, amqp_constants.TYPE_BODY, self.channel_id)
             content_frame.declare_class(amqp_constants.CLASS_BASIC)
             encoder = amqp_frame.AmqpEncoder()
-            if isinstance(chunk, str):
-                encoder.payload.write(chunk.encode())
-            else:
-                encoder.payload.write(chunk)
+            encoder.payload.write(chunk)
             content_frame.write_frame(encoder)
 
         yield from self.protocol.writer.drain()


### PR DESCRIPTION
```
=ERROR REPORT==== 16-Feb-2016::02:02:18 ===
Error on AMQP connection <0.25444.39> (172.17.0.1:56236 -> 172.17.0.19:5672, vhost: 'sync', user: 'some_producer', state: running), channel 1:
operation none caused a connection exception frame_error: "type 3, all octets = <<>>: {frame_too_large,131184,131064}"
```

I process the text data from external service, and sometimes it can contain some data like:

```
... \u2014 signal \u2014 medium ...
```

So after encode this string is increasing. 
