### PR TITLE
Isolate KeyErrors raised during frame dispatch

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -206,9 +206,10 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             return
 
         if frame.channel is not 0:
-            try:
-                yield from self.channels[frame.channel].dispatch_frame(frame)
-            except KeyError:
+            channel = self.channels.get(frame.channel)
+            if channel is not None:
+                yield from channel.dispatch_frame(frame)
+            else:
                 logger.info("Unknown channel %s", frame.channel)
             return
 


### PR DESCRIPTION
Should dispatch_frame (which may delegate to user callbacks) raise a KeyError, it isn't an unknown channel, so the log is misleading, and the exception should not be swallowed.