### PR TITLE
Create new task for devlier callbacks instead of call a blocking call

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -657,7 +657,7 @@ class Channel:
             yield from event.wait()
             del self._ctag_events[consumer_tag]
 
-        yield from callback(self, body, envelope, properties)
+        self._loop.call_soon(asyncio.async, callback(self, body, envelope, properties))
 
     @asyncio.coroutine
     def server_basic_cancel(self, frame):


### PR DESCRIPTION
I submitted the issue #87 some days ago. I managed to consume from multiple queues with multiple open channels. This bothered me a little. Why don't we just run the callback with `loop.call_soon` ?
I made this little change and tested with my code which waits for a response of a command (RPC) in a received event and it works fine. (I'm basically consuming from the response and event queue at the "same time" ...)

Do you guys see any problems with this fix?