### PR TITLE
add properties in channel.basic_get answer

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -717,6 +717,7 @@ class Channel:
             buffer.write(content_body_frame.payload)
 
         data['message'] = buffer.getvalue()
+        data['properties'] = content_header_frame.properties
         future = self._get_waiter('basic_get')
         future.set_result(data)
 

--- a/aioamqp/tests/test_basic.py
+++ b/aioamqp/tests/test_basic.py
@@ -9,6 +9,7 @@ import unittest
 from . import testcase
 from . import testing
 from .. import exceptions
+from .. import properties
 
 
 class QosTestCase(testcase.RabbitTestCase, unittest.TestCase):
@@ -99,6 +100,7 @@ class BasicGetTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertIn('delivery_tag', result)
         self.assertEqual(result['exchange_name'].split('.')[-1], exchange_name)
         self.assertEqual(result['message'], b'payload')
+        self.assertTrue(isinstance(result['properties'], properties.Properties))
 
     @testing.coroutine
     def test_basic_get_empty(self):


### PR DESCRIPTION
Hi,
I added properties into the channel.basic_get answer to be able to use the method for rpc calls.