### PR TITLE
Handle the server setting frame_max to zero

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -511,7 +511,7 @@ class Channel:
 
         # split the payload
 
-        frame_max = self.protocol.server_frame_max
+        frame_max = self.protocol.server_frame_max or len(payload)
         for chunk in (payload[0+i:frame_max+i] for i in range(0, len(payload), frame_max)):
 
             content_frame = amqp_frame.AmqpRequest(
@@ -834,7 +834,7 @@ class Channel:
 
         # split the payload
 
-        frame_max = self.protocol.server_frame_max
+        frame_max = self.protocol.server_frame_max or len(payload)
         for chunk in (payload[0+i:frame_max+i] for i in range(0, len(payload), frame_max)):
 
             content_frame = amqp_frame.AmqpRequest(


### PR DESCRIPTION
server_max_frame=0 is defined as "very large", thus don't split frames