### PR TITLE
frame_max error, heartbeat left when closing

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -510,7 +510,7 @@ class Channel:
 
         # split the payload
 
-        frame_max = self.protocol.server_frame_max
+        frame_max = self.protocol.server_frame_max or len(payload)
         for chunk in (payload[0+i:frame_max+i] for i in range(0, len(payload), frame_max)):
 
             content_frame = amqp_frame.AmqpRequest(
@@ -833,7 +833,7 @@ class Channel:
 
         # split the payload
 
-        frame_max = self.protocol.server_frame_max
+        frame_max = self.protocol.server_frame_max or len(payload)
         for chunk in (payload[0+i:frame_max+i] for i in range(0, len(payload), frame_max)):
 
             content_frame = amqp_frame.AmqpRequest(

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -120,6 +120,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         encoder.write_short(0)
         encoder.write_short(0)
         frame.write_frame(encoder)
+        self._stop_heartbeat()
         if not no_wait:
             yield from self.wait_closed(timeout=timeout)
 
@@ -366,11 +367,21 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         reply_text = response.read_shortstr()
         class_id = response.read_short()
         method_id = response.read_short()
+        self._stop_heartbeat()
         self.stop()
         logger.warning("Server closed connection: %s, code=%s, class_id=%s, method_id=%s",
             reply_text, reply_code, class_id, method_id)
         self._close_channels(reply_code, reply_text)
 
+    def _stop_heartbeat(self):
+        # prevent new timers from being created by overlapping traffic
+        self.server_heartbeat = 0
+        if self._heartbeat_timer_recv is not None:
+            self._heartbeat_timer_recv.cancel()
+            self._heartbeat_timer_recv = None
+        if self._heartbeat_timer_send is not None:
+            self._heartbeat_timer_send.cancel()
+            self._heartbeat_timer_send = None
 
     @asyncio.coroutine
     def tune(self, frame):


### PR DESCRIPTION
Two patches here:
* if the server reports a max frame of zero (some do: should be interpreted as "don't care"), aioamqp stops working. I think I already submitted that..? anyway it's still needed.
* When closing the protocol, sometimes the heartbeat timers are left running, which leads to spurious error messages later. This patch cancels them and prevents them from restarting.