### PR TITLE
Allow testing against a remote rabbitmq server

### DIFF
--- a/aioamqp/tests/test_connect.py
+++ b/aioamqp/tests/test_connect.py
@@ -12,7 +12,8 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_connect(self):
-        _transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop)
+        _transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop,
+            host=self.host,port=self.port,login=self.login,password=self.password)
         self.assertTrue(proto.is_open)
         self.assertIsNotNone(proto.server_properties)
         yield from proto.close()
@@ -29,6 +30,8 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
             channel_max=channel_max,
             frame_max=frame_max,
             heartbeat=heartbeat,
+            host=self.host, port=self.port,
+            login=self.login, password=self.password,
         )
         self.assertTrue(proto.is_open)
         self.assertIsNotNone(proto.server_properties)
@@ -47,7 +50,8 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_socket_nodelay(self):
-        transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop)
+        transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop,
+            host=self.host,port=self.port, login=self.login,password=self.password)
         sock = transport.get_extra_info('socket')
         opt_val = sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
         self.assertEqual(opt_val, 1)

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -19,7 +19,8 @@ class ProtocolTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_connect(self):
-        _transport, protocol = yield from amqp_connect(virtualhost=self.vhost, loop=self.loop)
+        _transport, protocol = yield from amqp_connect(virtualhost=self.vhost, loop=self.loop,
+            host=self.host,port=self.port, login=self.login,password=self.password)
         self.assertTrue(protocol.is_open)
         yield from protocol.close()
 
@@ -33,6 +34,8 @@ class ProtocolTestCase(testcase.RabbitTestCase, unittest.TestCase):
             virtualhost=self.vhost,
             client_properties=client_properties,
             loop=self.loop,
+            host=self.host,port=self.port,
+            login=self.login,password=self.password
         )
 
         self.assertEqual(protocol.client_properties, client_properties)
@@ -41,11 +44,13 @@ class ProtocolTestCase(testcase.RabbitTestCase, unittest.TestCase):
     @testing.coroutine
     def test_connection_unexistant_vhost(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):
-            yield from amqp_connect(virtualhost='/unexistant', loop=self.loop)
+            yield from amqp_connect(virtualhost='/unexistant', loop=self.loop,
+                host=self.host,port=self.port, login=self.login,password=self.password)
 
     def test_connection_wrong_login_password(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):
-            self.loop.run_until_complete(amqp_connect(login='wrong', password='wrong', loop=self.loop))
+            self.loop.run_until_complete(amqp_connect(login='wrong', password='wrong', loop=self.loop,
+                host=self.host,port=self.port))
 
     @testing.coroutine
     def test_connection_from_url(self):

--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -82,8 +82,11 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
         super().setUp()
         self.host = os.environ.get('AMQP_HOST', 'localhost')
         self.port = os.environ.get('AMQP_PORT', 5672)
+        self.login = os.environ.get('AMQP_USER', 'guest')
+        self.password = os.environ.get('AMQP_PASS', 'guest')
+        self.mgr_port = os.environ.get('AMQP_MGR_PORT', 15672)
         self.vhost = os.environ.get('AMQP_VHOST', self.VHOST + str(uuid.uuid4()))
-        self.http_client = pyrabbit.api.Client('localhost:15672/api/', 'guest', 'guest')
+        self.http_client = pyrabbit.api.Client('%s:%d/api/' % (self.host,self.mgr_port), self.login,self.password)
 
         self.amqps = []
         self.channels = []
@@ -101,7 +104,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
 
         self.http_client.create_vhost(self.vhost)
         self.http_client.set_vhost_permissions(
-            vname=self.vhost, username='guest', config='.*', rd='.*', wr='.*',
+            vname=self.vhost, username=self.login, config='.*', rd='.*', wr='.*',
         )
 
         @asyncio.coroutine
@@ -285,7 +288,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
             return ProxyAmqpProtocol(self, *args, **kw)
         vhost = vhost or self.vhost
         transport, protocol = yield from aioamqp_connect(host=self.host, port=self.port, virtualhost=vhost,
-            protocol_factory=protocol_factory, loop=self.loop)
+            protocol_factory=protocol_factory, loop=self.loop, login=self.login, password=self.password)
         self.amqps.append(protocol)
         self.transports.append(transport)
         return transport, protocol


### PR DESCRIPTION
Set AMQP_{HOST,PORT,MGR_PORT, USER,PASS} to appropriate values.
Defaults: localhost,5672,15672, guest,guest.
