### PR TITLE
Fix typo in queue_bind example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -239,7 +239,7 @@ This simple example creates a `queue`, an `exchange` and bind them together.
 
         channel = yield from protocol.channel()
         yield from channel.queue_declare(queue_name='queue')
-        yield from channel.exchange_declare(queue_name='exchange')
+        yield from channel.exchange_declare(exchange_name='exchange')
 
         yield from channel.queue_bind('queue', 'exchange', routing_key='')
 


### PR DESCRIPTION
exchange_name argument was being called queue_name in the example.