### PR TITLE
[WIP] First implementation of a new consumer API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+virtualenv
 .Python
 env/
 venv/
@@ -34,7 +35,7 @@ pip-delete-this-directory.txt
 .cache
 nosetests.xml
 coverage.xml
-
+cover
 # Translations
 *.mo
 
@@ -55,3 +56,4 @@ docs/_build/
 
 # editor stuffs
 *.swp
+.idea

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -15,3 +15,4 @@ AUTHORS are (and/or have been)::
     * Igor `mastak`
     * Hans Lellelid
     * `iceboy-sjtu`
+    * Sergio Medina Toledo

--- a/aioamqp/consumer.py
+++ b/aioamqp/consumer.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+import asyncio
+
+import sys
+
+PY35 = sys.version_info >= (3, 5)
+
+
+class Consumer:
+    def __init__(self, queue: asyncio.Queue, consumer_tag):
+        self.queue = queue
+        self.tag = consumer_tag
+        self.message = None
+
+    if PY35:
+        async def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            return self.fetch_message()
+
+    @asyncio.coroutine
+    def fetch_message(self):
+
+        self.message = yield from self.queue.get()
+        if self.message:
+            return self.message
+        else:
+            raise StopIteration()
+
+    def get_message(self):
+        return self.message

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -12,12 +12,10 @@ from . import exceptions
 from . import version
 from .compat import ensure_future
 
-
 logger = logging.getLogger(__name__)
 
 
 class _StreamWriter(asyncio.StreamWriter):
-
     def write(self, data):
         ret = super().write(data)
         self._protocol._heartbeat_timer_send_reset()
@@ -135,7 +133,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
 
     @asyncio.coroutine
     def start_connection(self, host, port, login, password, virtualhost, ssl=False,
-            login_method='AMQPLAIN', insist=False):
+                         login_method='AMQPLAIN', insist=False):
         """Initiate a connection at the protocol level
             We send `PROTOCOL_HEADER'
         """
@@ -194,8 +192,8 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         frame = yield from self.get_frame()
         yield from self.dispatch_frame(frame)
         if (frame.frame_type == amqp_constants.TYPE_METHOD and
-                frame.class_id == amqp_constants.CLASS_CONNECTION and
-                frame.method_id == amqp_constants.CONNECTION_CLOSE):
+                    frame.class_id == amqp_constants.CLASS_CONNECTION and
+                    frame.method_id == amqp_constants.CONNECTION_CLOSE):
             raise exceptions.AmqpClosedConnection()
 
         # for now, we read server's responses asynchronously
@@ -376,9 +374,8 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         method_id = response.read_short()
         self.stop()
         logger.warning("Server closed connection: %s, code=%s, class_id=%s, method_id=%s",
-            reply_text, reply_code, class_id, method_id)
+                       reply_text, reply_code, class_id, method_id)
         self._close_channels(reply_code, reply_text)
-
 
     @asyncio.coroutine
     def tune(self, frame):

--- a/aioamqp/tests/test_close.py
+++ b/aioamqp/tests/test_close.py
@@ -58,4 +58,4 @@ class CloseTestCase(testcase.RabbitTestCase, unittest.TestCase):
         yield from self.channel.queue_declare("q")
         yield from channel.close()
         with self.assertRaises(exceptions.ChannelClosed):
-            yield from channel.basic_consume(self.callback)
+            consumer = yield from channel.basic_consume()

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -132,14 +132,14 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # create an exclusive queue
         yield from self.channel.queue_declare("q", exclusive=True)
         # consume it
-        yield from self.channel.basic_consume(self.callback, queue_name="q", no_wait=False)
+        consumer = yield from self.channel.basic_consume(queue_name="q", no_wait=False)
         # create an other amqp connection
 
         _transport, protocol = yield from self.create_amqp()
         channel = yield from self.create_channel(amqp=protocol)
         # assert that this connection cannot connect to the queue
         with self.assertRaises(exceptions.ChannelClosed):
-            yield from channel.basic_consume(self.callback, queue_name="q", no_wait=False)
+            consumer = yield from channel.basic_consume(queue_name="q", no_wait=False)
         # amqp and channels are auto deleted by test case
 
     @testing.coroutine
@@ -147,12 +147,12 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # create a non-exclusive queue
         yield from self.channel.queue_declare('q', exclusive=False)
         # consume it
-        yield from self.channel.basic_consume(self.callback, queue_name='q', no_wait=False)
+        consumer = yield from self.channel.basic_consume(queue_name='q', no_wait=False)
         # create an other amqp connection
         _transport, protocol = yield from self.create_amqp()
         channel = yield from self.create_channel(amqp=protocol)
         # assert that this connection can connect to the queue
-        yield from channel.basic_consume(self.callback, queue_name='q', no_wait=False)
+        consumer = yield from channel.basic_consume(queue_name='q', no_wait=False)
 
 
 class QueueDeleteTestCase(testcase.RabbitTestCase, unittest.TestCase):

--- a/aioamqp/tests/test_server_basic_cancel.py
+++ b/aioamqp/tests/test_server_basic_cancel.py
@@ -20,10 +20,6 @@ class ServerBasicCancelTestCase(testcase.RabbitTestCase, unittest.TestCase):
         queue_name = 'queue_name'
         yield from self.channel.queue_declare(queue_name)
 
-        @asyncio.coroutine
-        def callback(body, envelope, properties):
-            pass
-
         channel2 = yield from self.amqp.channel()
         yield from channel2.queue_declare(queue_name)
         # delete queue (so the server send a cancel)
@@ -33,9 +29,9 @@ class ServerBasicCancelTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # get an exception on all following calls
         # the Queue won't exists anymore
         with self.assertRaises(exceptions.ChannelClosed) as cm:
-            yield from channel2.basic_consume(callback)
+            yield from channel2.basic_consume()
 
         self.assertEqual(cm.exception.code, 404)
 
         with self.assertRaises(exceptions.ChannelClosed):
-            yield from self.channel.basic_consume(callback)
+            yield from self.channel.basic_consume()

--- a/aioamqp/version.py
+++ b/aioamqp/version.py
@@ -1,2 +1,2 @@
-__version__ = '0.8.2'
+__version__ = '0.9.0'
 __packagename__ = 'aioamqp'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Aioamqp 0.9.0
+-------------
+
+ * Changed consumer API from callbacks to coroutines solving the problem of publish inside of a consumer callback
+
 Aioamqp 0.8.2
 -------------
 

--- a/docs/examples/hello_world.rst
+++ b/docs/examples/hello_world.rst
@@ -63,13 +63,21 @@ We have to ensure the queue is created. Queue declaration is indempotant.
     yield from channel.queue_declare(queue_name='hello')
 
 
-To consume a message, the library calls a callback (which **MUST** be a coroutine):
+To consume a message is used the Consumer object using an async iter if is python 3.5 or while with ``fetch_message`` and ``get_message`` if is python < 3.5:
 
  .. code-block:: python
 
-    @asyncio.coroutine
-    def callback(channel, body, envelope, properties):
+    consumer = yield from channel.basic_consume(queue_name='hello', no_ack=True)
+
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
         print(body)
 
-    yield from channel.basic_consume(callback, queue_name='hello', no_ack=True)
+For python 3.5 :
 
+.. code-block:: python
+
+    consumer = await channel.basic_consume(queue_name='hello', no_ack=True)
+
+    async for channel, body, envelope, properties in consumer:
+        print(body)

--- a/docs/examples/rpc.rst
+++ b/docs/examples/rpc.rst
@@ -40,12 +40,12 @@ Note: the client use a `waiter` (an asyncio.Event) which will be set when receiv
 Server
 ------
 
-When unqueing a message, the server will publish a response directly in the callback. The `correlation_id` is used to let the client know it's a response from this request.
+When unqueing a message, the server will enqueue a response directly in the consumer loop. The `correlation_id` is used to let the client know it's a response from this request.
 
  .. code-block:: python
 
-    @asyncio.coroutine
-    def on_request(channel, body, envelope, properties):
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
         n = int(body)
 
         print(" [.] fib(%s)" % n)

--- a/docs/examples/work_queue.rst
+++ b/docs/examples/work_queue.rst
@@ -41,14 +41,14 @@ Then, the worker configure the `QOS`: it specifies how the worker unqueues messa
     yield from channel.basic_qos(prefetch_count=1, prefetch_size=0, connection_global=False)
 
 
-Finaly we have to create a callback that will `ack` the message to mark it as `processed`.
-Note: the code in the callback calls `asyncio.sleep` to simulate an asyncio compatible task that takes time.
+Finaly we have to create a messages processor that will `ack` the message to mark it as `processed`.
+Note: the code in the while calls `asyncio.sleep` to simulate an asyncio compatible task that takes time.
 You probably want to block the eventloop to simulate a CPU intensive task using `time.sleep`.
 
  .. code-block:: python
 
-    @asyncio.coroutine
-    def callback(channel, body, envelope, properties):
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
         print(" [x] Received %r" % body)
         yield from asyncio.sleep(body.count(b'.'))
         print(" [x] Done")

--- a/examples/receive.py
+++ b/examples/receive.py
@@ -8,18 +8,17 @@ import aioamqp
 
 
 @asyncio.coroutine
-def callback(channel, body, envelope, properties):
-    print(" [x] Received %r" % body)
-
-@asyncio.coroutine
 def receive():
     transport, protocol = yield from aioamqp.connect()
     channel = yield from protocol.channel()
 
     yield from channel.queue_declare(queue_name='hello')
 
-    yield from channel.basic_consume(callback, queue_name='hello')
+    consumer = yield from channel.basic_consume(queue_name='hello')
 
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
+        print(" [x] Received %r" % body)
 
 event_loop = asyncio.get_event_loop()
 event_loop.run_until_complete(receive())

--- a/examples/receive_log.py
+++ b/examples/receive_log.py
@@ -11,12 +11,6 @@ import aioamqp
 import random
 
 
-
-@asyncio.coroutine
-def callback(channel, body, envelope, properties):
-    print(" [x] %r" % body)
-
-
 @asyncio.coroutine
 def receive_log():
     try:
@@ -39,7 +33,11 @@ def receive_log():
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
-    yield from channel.basic_consume(callback, queue_name=queue_name, no_ack=True)
+    consumer = yield from channel.basic_consume(queue_name=queue_name, no_ack=True)
+
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
+        print(" [x] %r" % body)
 
 event_loop = asyncio.get_event_loop()
 event_loop.run_until_complete(receive_log())

--- a/examples/receive_log_topic.py
+++ b/examples/receive_log_topic.py
@@ -14,11 +14,6 @@ import sys
 
 
 @asyncio.coroutine
-def callback(channel, body, envelope, properties):
-    print("consumer {} received {} ({})".format(envelope.consumer_tag, body, envelope.delivery_tag))
-
-
-@asyncio.coroutine
 def receive_log():
     try:
         transport, protocol = yield from aioamqp.connect('localhost', 5672)
@@ -48,7 +43,11 @@ def receive_log():
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
-    yield from channel.basic_consume(callback, queue_name=queue_name)
+    consumer = yield from channel.basic_consume(queue_name=queue_name)
+
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
+        print("consumer {} received {} ({})".format(envelope.consumer_tag, body, envelope.delivery_tag))
 
 event_loop = asyncio.get_event_loop()
 event_loop.run_until_complete(receive_log())

--- a/examples/rpc_server.py
+++ b/examples/rpc_server.py
@@ -16,25 +16,6 @@ def fib(n):
 
 
 @asyncio.coroutine
-def on_request(channel, body, envelope, properties):
-    n = int(body)
-
-    print(" [.] fib(%s)" % n)
-    response = fib(n)
-
-    yield from channel.basic_publish(
-        payload=str(response),
-        exchange_name='',
-        routing_key=properties.reply_to,
-        properties={
-            'correlation_id': properties.correlation_id,
-        },
-    )
-
-    yield from channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
-    
-
-@asyncio.coroutine
 def rpc_server():
 
     transport, protocol = yield from aioamqp.connect()
@@ -43,9 +24,26 @@ def rpc_server():
 
     yield from channel.queue_declare(queue_name='rpc_queue')
     yield from channel.basic_qos(prefetch_count=1, prefetch_size=0, connection_global=False)
-    yield from channel.basic_consume(on_request, queue_name='rpc_queue')
+    consumer = yield from channel.basic_consume(queue_name='rpc_queue')
     print(" [x] Awaiting RPC requests")
 
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
+        n = int(body)
+
+        print(" [.] fib(%s)" % n)
+        response = fib(n)
+
+        yield from channel.basic_publish(
+            payload=str(response),
+            exchange_name='',
+            routing_key=properties.reply_to,
+            properties={
+                'correlation_id': properties.correlation_id,
+            },
+        )
+
+        yield from channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
 
 event_loop = asyncio.get_event_loop()
 event_loop.run_until_complete(rpc_server())

--- a/examples/worker.py
+++ b/examples/worker.py
@@ -8,13 +8,6 @@ import aioamqp
 
 import sys
 
-@asyncio.coroutine
-def callback(channel, body, envelope, properties):
-    print(" [x] Received %r" % body)
-    yield from asyncio.sleep(body.count(b'.'))
-    print(" [x] Done")
-    yield from channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
-
 
 @asyncio.coroutine
 def worker():
@@ -24,17 +17,20 @@ def worker():
         print("closed connections")
         return
 
-
     channel = yield from protocol.channel()
 
     yield from channel.queue(queue_name='task_queue', durable=True)
     yield from channel.basic_qos(prefetch_count=1, prefetch_size=0, connection_global=False)
-    yield from channel.basic_consume(callback, queue_name='task_queue')
+    consumer = yield from channel.basic_consume(queue_name='task_queue')
+
+    while (yield from consumer.fetch_message()):
+        channel, body, envelope, properties = consumer.get_message()
+        print(" [x] Received %r" % body)
+        yield from asyncio.sleep(body.count(b'.'))
+        print(" [x] Done")
+        yield from channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
 
 
 event_loop = asyncio.get_event_loop()
 event_loop.run_until_complete(worker())
 event_loop.run_forever()
-
-
-


### PR DESCRIPTION
First implementation of a new consumer API, as I propose in #87

- Added Consumer class to handle messages consumsion
- Added consumer queues in channels to wire the Consumer with the Channel
- Fixed all test
- Added test of stop of consumsion
- Fixed documentation
- Updated examples
- Updated version to 0.9.0 as the API breaks from 0.8.2

I would like a review from polyconseil and some feedback, I think that this API can be a good one.