### PR TITLE
Drain lock

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -113,7 +113,7 @@ class Channel:
             raise exceptions.ChannelClosed()
         frame.write_frame(request)
         if drain:
-            yield from self.protocol._stream_writer.drain()
+            yield from self.protocol._drain()
 
     @asyncio.coroutine
     def _write_frame_awaiting_response(self, waiter_id, frame, request, no_wait, check_open=True, drain=True):
@@ -508,7 +508,7 @@ class Channel:
                 encoder.payload.write(chunk)
             yield from self._write_frame(content_frame, encoder, drain=False)
 
-        yield from self.protocol._stream_writer.drain()
+        yield from self.protocol._drain()
 
     @asyncio.coroutine
     def basic_qos(self, prefetch_size=0, prefetch_count=0, connection_global=None):
@@ -826,7 +826,7 @@ class Channel:
                 encoder.payload.write(chunk)
             yield from self._write_frame(content_frame, encoder, drain=False)
 
-        yield from self.protocol._stream_writer.drain()
+        yield from self.protocol._drain()
 
         if self.publisher_confirms:
             yield from fut

--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -113,6 +113,21 @@ class Channel:
             raise exceptions.ChannelClosed()
         frame.write_frame(request)
 
+    @asyncio.coroutine
+    def _write_frame_awaiting_response(self, waiter_id, frame, request, no_wait, check_open=True):
+        '''Write a frame and set a waiter for the response (unless no_wait is set)'''
+        if no_wait:
+            yield from self._write_frame(frame, request, check_open=check_open)
+        else:
+            f = self._set_waiter(waiter_id)
+            try:
+                yield from self._write_frame(frame, request, check_open=check_open)
+            except Exception:
+                self._get_waiter(waiter_id)
+                f.cancel()
+                raise
+            return (yield from f)
+
 #
 ## Channel class implementation
 #
@@ -177,21 +192,6 @@ class Channel:
             'method_id': frame.payload_decoder.read_short(),
         }
         self.connection_closed(results['reply_code'], results['reply_text'])
-
-    @asyncio.coroutine
-    def _write_frame_awaiting_response(self, waiter_id, frame, request, no_wait, check_open=True):
-        '''Write a frame and set a waiter for the response (unless no_wait is set)'''
-        if no_wait:
-            yield from self._write_frame(frame, request, check_open=check_open)
-        else:
-            f = self._set_waiter(waiter_id)
-            try:
-                yield from self._write_frame(frame, request, check_open=check_open)
-            except Exception:
-                self._get_waiter(waiter_id)
-                f.cancel()
-                raise
-            return (yield from f)
 
     @asyncio.coroutine
     def flow(self, active):

--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -107,9 +107,9 @@ class Channel:
         yield from methods[(frame.class_id, frame.method_id)](frame)
 
     @asyncio.coroutine
-    def _write_frame(self, frame, request, no_check_open=False):
+    def _write_frame(self, frame, request, check_open=True):
         yield from self.protocol.ensure_open()
-        if not self.is_open and not no_check_open:
+        if not self.is_open and check_open:
             raise exceptions.ChannelClosed()
         frame.write_frame(request)
 
@@ -127,7 +127,7 @@ class Channel:
         request.write_shortstr('')
         fut = self._set_waiter('open')
         try:
-            yield from self._write_frame(frame, request, no_check_open=True)
+            yield from self._write_frame(frame, request, check_open=False)
         except Exception:
             self._get_waiter('open')
             fut.cancel()
@@ -210,7 +210,7 @@ class Channel:
         request.write_bits(active)
         return (yield from self._write_frame_awaiting_response(
             'flow', frame, request, no_wait=False,
-            no_check_open=True))
+            check_open=False))
 
     @asyncio.coroutine
     def flow_ok(self, frame):

--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -107,7 +107,7 @@ class Channel:
         yield from methods[(frame.class_id, frame.method_id)](frame)
 
     @asyncio.coroutine
-    def _write_frame(self, frame, request, no_wait, no_check_open=False):
+    def _write_frame(self, frame, request, no_check_open=False):
         yield from self.protocol.ensure_open()
         if not self.is_open and not no_check_open:
             raise exceptions.ChannelClosed()
@@ -127,7 +127,7 @@ class Channel:
         request.write_shortstr('')
         fut = self._set_waiter('open')
         try:
-            yield from self._write_frame(frame, request, no_wait=False, no_check_open=True)
+            yield from self._write_frame(frame, request, no_check_open=True)
         except Exception:
             self._get_waiter('open')
             fut.cancel()
@@ -173,7 +173,7 @@ class Channel:
         frame.declare_method(
             amqp_constants.CLASS_CHANNEL, amqp_constants.CHANNEL_CLOSE_OK)
         request = amqp_frame.AmqpEncoder()
-        yield from self._write_frame(frame, request, no_wait=False)
+        yield from self._write_frame(frame, request)
 
     @asyncio.coroutine
     def server_channel_close(self, frame):
@@ -190,11 +190,11 @@ class Channel:
     def _write_frame_awaiting_response(self, waiter_id, frame, request, no_wait, **kwargs):
         '''Write a frame and set a waiter for the response (unless no_wait is set)'''
         if no_wait:
-            yield from self._write_frame(frame, request, no_wait=True, **kwargs)
+            yield from self._write_frame(frame, request, **kwargs)
         else:
             f = self._set_waiter(waiter_id)
             try:
-                yield from self._write_frame(frame, request, no_wait=False, **kwargs)
+                yield from self._write_frame(frame, request, **kwargs)
             except Exception:
                 self._get_waiter(waiter_id)
                 f.cancel()
@@ -464,10 +464,10 @@ class Channel:
         request.write_octet(int(no_wait))
         if not no_wait:
             future = self._set_waiter('queue_purge')
-            yield from self._write_frame(frame, request, no_wait)
+            yield from self._write_frame(frame, request)
             return (yield from future)
 
-        yield from self._write_frame(frame, request, no_wait)
+        yield from self._write_frame(frame, request)
 
     @asyncio.coroutine
     def queue_purge_ok(self, frame):
@@ -551,7 +551,7 @@ class Channel:
         request.write_bits(connection_global)
 
         future = self._set_waiter('basic_qos')
-        yield from self._write_frame(frame, request, no_wait=False)
+        yield from self._write_frame(frame, request)
         return (yield from future)
 
     @asyncio.coroutine
@@ -732,7 +732,7 @@ class Channel:
         request = amqp_frame.AmqpEncoder()
         request.write_long_long(delivery_tag)
         request.write_bits(multiple)
-        yield from self._write_frame(frame, request, no_wait=False)
+        yield from self._write_frame(frame, request)
 
     @asyncio.coroutine
     def basic_client_nack(self, delivery_tag, multiple=False, requeue=True):
@@ -743,7 +743,7 @@ class Channel:
         request = amqp_frame.AmqpEncoder()
         request.write_long_long(delivery_tag)
         request.write_bits(multiple, requeue)
-        yield from self._write_frame(frame, request, no_wait=False)
+        yield from self._write_frame(frame, request)
 
 
     @asyncio.coroutine
@@ -763,7 +763,7 @@ class Channel:
         request = amqp_frame.AmqpEncoder()
         request.write_long_long(delivery_tag)
         request.write_bits(requeue)
-        yield from self._write_frame(frame, request, no_wait=False)
+        yield from self._write_frame(frame, request)
 
     @asyncio.coroutine
     def basic_recover_async(self, requeue=True):
@@ -773,7 +773,7 @@ class Channel:
             amqp_constants.CLASS_BASIC, amqp_constants.BASIC_RECOVER_ASYNC)
         request = amqp_frame.AmqpEncoder()
         request.write_bits(requeue)
-        yield from self._write_frame(frame, request, no_wait=False)
+        yield from self._write_frame(frame, request)
 
     @asyncio.coroutine
     def basic_recover(self, requeue=True):

--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -187,14 +187,14 @@ class Channel:
         self.connection_closed(results['reply_code'], results['reply_text'])
 
     @asyncio.coroutine
-    def _write_frame_awaiting_response(self, waiter_id, frame, request, no_wait, **kwargs):
+    def _write_frame_awaiting_response(self, waiter_id, frame, request, no_wait, check_open=True):
         '''Write a frame and set a waiter for the response (unless no_wait is set)'''
         if no_wait:
-            yield from self._write_frame(frame, request, **kwargs)
+            yield from self._write_frame(frame, request, check_open=check_open)
         else:
             f = self._set_waiter(waiter_id)
             try:
-                yield from self._write_frame(frame, request, **kwargs)
+                yield from self._write_frame(frame, request, check_open=check_open)
             except Exception:
                 self._get_waiter(waiter_id)
                 f.cancel()

--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -349,10 +349,8 @@ class AmqpRequest:
         self.class_id = class_id
         self.method_id = method_id
 
-    def write_frame(self, encoder=None):
-        payload = None
-        if encoder is not None:
-            payload = encoder.payload
+    def write_frame(self, encoder):
+        payload = encoder.payload
         content_header = ''
         transmission = io.BytesIO()
         if self.frame_type == amqp_constants.TYPE_METHOD:
@@ -372,8 +370,7 @@ class AmqpRequest:
         transmission.write(header)
         if content_header:
             transmission.write(content_header)
-        if payload:
-            transmission.write(payload.getvalue())
+        transmission.write(payload.getvalue())
         transmission.write(amqp_constants.FRAME_END)
         return self.writer.write(transmission.getvalue())
 

--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -336,7 +336,6 @@ class AmqpRequest:
         self.class_id = None
         self.weight = None
         self.method_id = None
-        self.payload = None
         self.next_body_size = None
 
     def declare_class(self, class_id, weight=0):

--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -56,7 +56,7 @@ DUMP_FRAMES = False
 
 class AmqpEncoder:
 
-    def __init__(self, writer=None):
+    def __init__(self):
         self.payload = io.BytesIO()
 
     def write_table(self, data_dict):

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -139,7 +139,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         frame = amqp_frame.AmqpRequest(self._stream_writer, amqp_constants.TYPE_METHOD, 0)
         frame.declare_method(
             amqp_constants.CLASS_CONNECTION, amqp_constants.CONNECTION_CLOSE)
-        encoder = amqp_frame.AmqpEncoder(frame.payload)
+        encoder = amqp_frame.AmqpEncoder()
         # we request a clean connection close
         encoder.write_short(0)
         encoder.write_shortstr('')

--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -203,7 +203,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
         channel = channel or self.channel
         full_queue_name = self.full_name(queue_name)
         try:
-            yield from channel.queue_delete(full_queue_name, no_wait=False, timeout=1.0)
+            yield from channel.queue_delete(full_queue_name, no_wait=False)
         except asyncio.TimeoutError:
             logger.warning('Timeout on queue %s deletion', full_queue_name, exc_info=True)
         except Exception:  # pylint: disable=broad-except
@@ -218,7 +218,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
         channel = channel or self.channel
         full_exchange_name = self.full_name(exchange_name)
         try:
-            yield from channel.exchange_delete(full_exchange_name, no_wait=False, timeout=1.0)
+            yield from channel.exchange_delete(full_exchange_name, no_wait=False)
         except asyncio.TimeoutError:
             logger.warning('Timeout on exchange %s deletion', full_exchange_name, exc_info=True)
         except Exception:  # pylint: disable=broad-except


### PR DESCRIPTION
Various spring cleanups and small refactoring that lead to adding a lock around calls to `Protocol.drain()`.

See the links below as to why this is necessary:

* http://bugs.python.org/issue29930
* https://github.com/aaugustin/websockets/issues/16