### PR TITLE
The protocol class was modified to keep the connection alive when the…

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -368,7 +368,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         self._stream_writer.close()
 
     def _heartbeat_timer_recv_reset(self):
-        if self.server_heartbeat is None:
+        if self.server_heartbeat is None or self.server_heartbeat is 0:
             return
         if self._heartbeat_timer_recv is not None:
             self._heartbeat_timer_recv.cancel()
@@ -377,7 +377,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             self._heartbeat_timer_recv_timeout)
 
     def _heartbeat_timer_send_reset(self):
-        if self.server_heartbeat is None:
+        if self.server_heartbeat is None or self.server_heartbeat is 0:
             return
         if self._heartbeat_timer_send is not None:
             self._heartbeat_timer_send.cancel()


### PR DESCRIPTION
The protocol class was modified to keep the connection alive when the heartbeat parameter is 0.
Fixes issue [#119](https://github.com/Polyconseil/aioamqp/issues/119)