### PR TITLE
Allow ssl.SSLContext instance to be supplied to connect and from_url …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # editor stuffs
 *.swp
+
+# Pycharm/IntelliJ
+.idea/*

--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -40,7 +40,7 @@ async def connect(host='localhost', port=None, login='guest', password='guest',
     create_connection_kwargs = {}
 
     if ssl:
-        ssl_context = ssl_module.create_default_context()
+        ssl_context = ssl_module.create_default_context() if isinstance(ssl, bool) else ssl
         if not verify_ssl:
             ssl_context.check_hostname = False
             ssl_context.verify_mode = ssl_module.CERT_NONE
@@ -104,10 +104,9 @@ async def from_url(
         login=url.username or 'guest',
         password=url.password or 'guest',
         virtualhost=(url.path[1:] if len(url.path) > 1 else '/'),
-        ssl=(url.scheme == 'amqps'),
         login_method=login_method,
         insist=insist,
         protocol_factory=protocol_factory,
         verify_ssl=verify_ssl,
-        **kwargs)
+        **dict(kwargs, ssl=kwargs.get('ssl', url.scheme == 'amqps')))
     return transport, protocol

--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import socket
-import ssl as ssl_module  # import as to enable argument named ssl in connect
 from urllib.parse import urlparse
 
 from .exceptions import *  # pylint: disable=wildcard-import
@@ -12,7 +11,7 @@ from .version import __packagename__
 
 async def connect(host='localhost', port=None, login='guest', password='guest',
             virtualhost='/', ssl=None, login_method='AMQPLAIN', insist=False,
-            protocol_factory=AmqpProtocol, *, verify_ssl=True, loop=None, **kwargs):
+            protocol_factory=AmqpProtocol, *, loop=None, **kwargs):
     """Convenient method to connect to an AMQP broker
 
         @host:          the host to connect to
@@ -22,7 +21,6 @@ async def connect(host='localhost', port=None, login='guest', password='guest',
         @virtualhost:   AMQP virtualhost to use for this connection
         @ssl:           SSL context used for secure connections, omit for no SSL
                         - see https://docs.python.org/3/library/ssl.html
-        @verify_ssl:    Verify server's SSL certificate (True by default)
         @login_method:  AMQP auth method
         @insist:        Insist on connecting to a server
         @protocol_factory:
@@ -40,9 +38,6 @@ async def connect(host='localhost', port=None, login='guest', password='guest',
     create_connection_kwargs = {}
 
     if ssl is not None:
-        if not verify_ssl:
-            ssl.check_hostname = False
-            ssl.verify_mode = ssl_module.CERT_NONE
         create_connection_kwargs['ssl'] = ssl
 
     if port is None:
@@ -74,8 +69,7 @@ async def connect(host='localhost', port=None, login='guest', password='guest',
 
 
 async def from_url(
-        url, login_method='AMQPLAIN', insist=False, protocol_factory=AmqpProtocol, *,
-        verify_ssl=True, **kwargs):
+        url, login_method='AMQPLAIN', insist=False, protocol_factory=AmqpProtocol, **kwargs):
     """ Connect to the AMQP using a single url parameter and return the client.
 
         For instance:
@@ -85,7 +79,6 @@ async def from_url(
         @insist:        Insist on connecting to a server
         @protocol_factory:
                         Factory to use, if you need to subclass AmqpProtocol
-        @verify_ssl:    Verify server's SSL certificate (True by default)
         @loop:          optionally set the event loop to use.
 
         @kwargs:        Arguments to be given to the protocol_factory instance
@@ -106,6 +99,5 @@ async def from_url(
         login_method=login_method,
         insist=insist,
         protocol_factory=protocol_factory,
-        verify_ssl=verify_ssl,
         **kwargs)
     return transport, protocol

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -4,6 +4,7 @@
 
 import asynctest
 from unittest import mock
+import ssl as ssl_module
 
 from . import testcase
 from .. import exceptions
@@ -59,6 +60,47 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
                 password='pass',
                 login_method='AMQPLAIN',
                 ssl=False,
+                login='tom',
+                host='example.com',
+                protocol_factory=AmqpProtocol,
+                virtualhost='myvhost',
+                port=7777,
+                verify_ssl=True,
+                loop=self.loop,
+            )
+
+    async def test_ssl_connection_from_url(self):
+        with mock.patch('aioamqp.connect') as connect:
+            async def func(*x, **y):
+                return 1, 2
+            connect.side_effect = func
+            await amqp_from_url('amqps://tom:pass@example.com:7777/myvhost', loop=self.loop)
+            connect.assert_called_once_with(
+                insist=False,
+                password='pass',
+                login_method='AMQPLAIN',
+                ssl=True,
+                login='tom',
+                host='example.com',
+                protocol_factory=AmqpProtocol,
+                virtualhost='myvhost',
+                port=7777,
+                verify_ssl=True,
+                loop=self.loop,
+            )
+
+    async def test_ssl_context_connection_from_url(self):
+        ssl_context = ssl_module.create_default_context()
+        with mock.patch('aioamqp.connect') as connect:
+            async def func(*x, **y):
+                return 1, 2
+            connect.side_effect = func
+            await amqp_from_url('amqp://tom:pass@example.com:7777/myvhost', loop=self.loop, ssl=ssl_context)
+            connect.assert_called_once_with(
+                insist=False,
+                password='pass',
+                login_method='AMQPLAIN',
+                ssl=ssl_context,
                 login='tom',
                 host='example.com',
                 protocol_factory=AmqpProtocol,

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -4,7 +4,6 @@
 
 import asynctest
 from unittest import mock
-import ssl as ssl_module
 
 from . import testcase
 from .. import exceptions
@@ -90,7 +89,7 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
             )
 
     async def test_ssl_context_connection_from_url(self):
-        ssl_context = ssl_module.create_default_context()
+        ssl_context = mock.Mock()
         with mock.patch('aioamqp.connect') as connect:
             async def func(*x, **y):
                 return 1, 2

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -61,7 +61,6 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
                 protocol_factory=AmqpProtocol,
                 virtualhost='myvhost',
                 port=7777,
-                verify_ssl=True,
                 loop=self.loop,
             )
 
@@ -82,7 +81,6 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
                 protocol_factory=AmqpProtocol,
                 virtualhost='myvhost',
                 port=7777,
-                verify_ssl=True,
                 loop=self.loop,
             )
 

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -56,7 +56,6 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
                 insist=False,
                 password='pass',
                 login_method='AMQPLAIN',
-                ssl=False,
                 login='tom',
                 host='example.com',
                 protocol_factory=AmqpProtocol,

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -1,7 +1,6 @@
 """
     Test our Protocol class
 """
-
 import asynctest
 from unittest import mock
 
@@ -13,7 +12,6 @@ from ..protocol import AmqpProtocol, OPEN
 
 
 class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
-
 
     async def test_connect(self):
         _transport, protocol = await amqp_connect(
@@ -68,33 +66,13 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
                 loop=self.loop,
             )
 
-    async def test_ssl_connection_from_url(self):
-        with mock.patch('aioamqp.connect') as connect:
-            async def func(*x, **y):
-                return 1, 2
-            connect.side_effect = func
-            await amqp_from_url('amqps://tom:pass@example.com:7777/myvhost', loop=self.loop)
-            connect.assert_called_once_with(
-                insist=False,
-                password='pass',
-                login_method='AMQPLAIN',
-                ssl=True,
-                login='tom',
-                host='example.com',
-                protocol_factory=AmqpProtocol,
-                virtualhost='myvhost',
-                port=7777,
-                verify_ssl=True,
-                loop=self.loop,
-            )
-
     async def test_ssl_context_connection_from_url(self):
         ssl_context = mock.Mock()
         with mock.patch('aioamqp.connect') as connect:
             async def func(*x, **y):
                 return 1, 2
             connect.side_effect = func
-            await amqp_from_url('amqp://tom:pass@example.com:7777/myvhost', loop=self.loop, ssl=ssl_context)
+            await amqp_from_url('amqps://tom:pass@example.com:7777/myvhost', loop=self.loop, ssl=ssl_context)
             connect.assert_called_once_with(
                 insist=False,
                 password='pass',


### PR DESCRIPTION
Its impossible to use client side certificates with a TLS termination proxy to connect to rabbitmq without having control over the ssl.SSLContext. This change is a simple one that makes the from_url and connect methods behaviour like the loop.create_connection() they ultimately call. This will also make using self signed certificates since they don't have to be installed in an OS dependant manner but instead can just be referenced by the path in the supplied context. See #91 