### PR TITLE
add StreamReader check 

### DIFF
--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -405,6 +405,8 @@ class AmqpResponse:
     def read_frame(self):
         """Decode the frame"""
         try:
+            if not self.reader:
+                raise exceptions.AmqpClosedConnection()
             data = yield from self.reader.readexactly(7)
         except (asyncio.IncompleteReadError, socket.error) as ex:
             raise exceptions.AmqpClosedConnection() from ex

--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -404,9 +404,9 @@ class AmqpResponse:
     @asyncio.coroutine
     def read_frame(self):
         """Decode the frame"""
+        if not self.reader:
+            raise exceptions.AmqpClosedConnection()
         try:
-            if not self.reader:
-                raise exceptions.AmqpClosedConnection()
             data = yield from self.reader.readexactly(7)
         except (asyncio.IncompleteReadError, socket.error) as ex:
             raise exceptions.AmqpClosedConnection() from ex


### PR DESCRIPTION
StreamReader in Python3.5 sets to None in connection_lost method. Occasionally, this leads to endless exception throw.

This fix may close issue #115.