### PR TITLE
Testcase fix-ups

### DIFF
--- a/aioamqp/tests/test_basic.py
+++ b/aioamqp/tests/test_basic.py
@@ -66,8 +66,6 @@ class BasicCancelTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
         result = yield from self.channel.publish("payload", exchange_name, routing_key='')
 
-        yield from asyncio.sleep(5, loop=self.loop)
-
         result = yield from self.channel.queue_declare(queue_name, passive=True)
         self.assertEqual(result['message_count'], 1)
         self.assertEqual(result['consumer_count'], 0)

--- a/aioamqp/tests/test_consume.py
+++ b/aioamqp/tests/test_consume.py
@@ -49,7 +49,6 @@ class ConsumeTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertIn("q", queues)
         self.assertEqual(1, queues["q"]['messages'])
 
-        yield from asyncio.sleep(2, loop=self.loop)
         # start consume
         with self.assertRaises(exceptions.ConfigurationError):
             yield from channel.basic_consume(badcallback, queue_name="q")

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -98,15 +98,25 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         # declared queue we have to use self.full_name function
         self.assertEqual(self.full_name(queue_name), result['queue'])
 
-        queues = self.list_queues()
-        queue = queues[queue_name]
+        for x in range(5):
+            try:
+                queues = self.list_queues()
+                queue = queues[queue_name]
 
-        # assert queue has been declared witht the good arguments
-        self.assertEqual(queue_name, queue['name'])
-        self.assertEqual(0, queue['consumers'])
-        self.assertEqual(0, queue['messages_ready'])
-        self.assertEqual(auto_delete, queue['auto_delete'])
-        self.assertEqual(durable, queue['durable'])
+                # assert queue has been declared witht the good arguments
+                self.assertEqual(queue_name, queue['name'])
+                self.assertEqual(0, queue['consumers'])
+                self.assertEqual(0, queue['messages_ready'])
+                self.assertEqual(auto_delete, queue['auto_delete'])
+                self.assertEqual(durable, queue['durable'])
+            except (KeyError, AssertionError) as exc:
+                ex = exc
+            else:
+                break
+            asyncio.sleep(0.5, loop=self.loop)
+        else:
+            raise ex
+
 
         # delete queue
         yield from self.safe_queue_delete(queue_name)

--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -81,10 +81,10 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
     def setUp(self):
         super().setUp()
         self.host = os.environ.get('AMQP_HOST', 'localhost')
-        self.port = os.environ.get('AMQP_PORT', 5672)
+        self.port = int(os.environ.get('AMQP_PORT', 5672))
         self.vhost = os.environ.get('AMQP_VHOST', self.VHOST + str(uuid.uuid4()))
         self.http_client = pyrabbit.api.Client(
-            'localhost:15672/api/', 'guest', 'guest', timeout=20
+            '%s:%s/' % (self.host, 10000+self.port), 'guest', 'guest', timeout=20
         )
 
         self.amqps = []
@@ -184,7 +184,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
 
     def list_queues(self, vhost=None, fully_qualified_name=False):
         # wait for the http client to get the correct state of the queue
-        time.sleep(int(os.environ.get('AMQP_REFRESH_TIME', 6)))
+        time.sleep(int(os.environ.get('AMQP_REFRESH_TIME', 1.1)))
         queues_list = self.http_client.get_queues(vhost=vhost or self.vhost)
         queues = {}
         for queue_info in queues_list:


### PR DESCRIPTION
Some calls to sleep() are superfluous. Others are missing.

For missing sleep calls, retry a few times instead of using a worst-case timeout. The test run is slow enough as is.