### PR TITLE
Warn "Connection lost" only if it losts unexpectedly

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -110,7 +110,8 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         return False
 
     def connection_lost(self, exc):
-        logger.warning("Connection lost exc=%r", exc)
+        if exc is not None:
+            logger.warning("Connection lost exc=%r", exc)
         self.connection_closed.set()
         self.state = CLOSED
         self._close_channels(exception=exc)


### PR DESCRIPTION
There is an annoying warning which occurs when behavior is regular.