### PR TITLE
Drop support for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- 3.3
 - 3.4
 - 3.5
 - 3.6

--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -1,6 +1,5 @@
 import asyncio
 import socket
-import sys
 import ssl as ssl_module  # import as to enable argument named ssl in connect
 from urllib.parse import urlparse
 
@@ -41,8 +40,6 @@ def connect(host='localhost', port=None, login='guest', password='guest',
     create_connection_kwargs = {}
 
     if ssl:
-        if sys.version_info < (3, 4):
-            raise NotImplementedError('SSL not supported on Python 3.3 yet')
         ssl_context = ssl_module.create_default_context()
         if not verify_ssl:
             ssl_context.check_hostname = False

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,14 +1,13 @@
 Introduction
 ============
 
-Aioamqp library is a pure-Python implementation of the AMQP 0.9.1 protocol using `asyncio`.
+Aioamqp library is a pure-Python implementation of the AMQP 0.9.1 protocol using `asyncio`_.
 
 
 Prerequisites
 -------------
 
-Aioamqp works only with python >= 3.3 using asyncio library.
-If your are using Python 3.3 you'll have to install asyncio from pypi, but asyncio is now included in python 3.4 standard library.
+Aioamqp works only with python >= 3.4 using the asyncio module from the standard library.
 
 Installation
 ------------
@@ -18,3 +17,6 @@ You can install the most recent aioamqp release from pypi using pip or easy_inst
  .. code-block:: shell
 
     pip install aioamqp
+
+
+.. _asyncio: https://docs.python.org/3/library/asyncio.html

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py33.py34.py35
+python-tag = py34.py35

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ setuptools.setup(
     packages=[
         'aioamqp',
     ],
-    extras_require={
-        ':python_version=="3.3"': ['asyncio'],
-    },
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
@@ -33,7 +30,6 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36
+envlist = py34, py35, py36
 skipsdist = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
It reached its end-of-life in September 2017, see https://www.python.org/dev/peps/pep-0398/#id21

ref Polyconseil/aioamqp#123