### PR TITLE
Add consumer cancellation callback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,11 @@ SPHINXBUILDDIR ?= $(BUILD_DIR)/sphinx/html
 ALLSPHINXOPTS ?= -d $(BUILD_DIR)/sphinx/doctrees $(SPHINXOPTS) docs
 
 doc:
+	@ pip install -q Sphinx sphinx-rtd-theme
 	sphinx-build -a $(INPUT_DIR) build
 
 livehtml: docs
+	@ pip install -q Sphinx sphinx-rtd-theme
 	sphinx-autobuild $(AUTOSPHINXOPTS) $(ALLSPHINXOPTS) $(SPHINXBUILDDIR)
 
 test:

--- a/aioamqp/tests/test_connect.py
+++ b/aioamqp/tests/test_connect.py
@@ -51,5 +51,5 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
         transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop)
         sock = transport.get_extra_info('socket')
         opt_val = sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
-        self.assertEqual(opt_val, 1)
+        self.assertNotEqual(opt_val, 0)
         yield from proto.close()

--- a/aioamqp/tests/test_server_basic_cancel.py
+++ b/aioamqp/tests/test_server_basic_cancel.py
@@ -3,21 +3,72 @@
 
 """
 
-import unittest
+import asyncio
+import unittest.mock
+import uuid
 
 from . import testcase
 from . import testing
 
 
+@asyncio.coroutine
+def consumer(channel, body, envelope, properties):
+    yield from channel.basic_client_ack(envelope.delivery_tag)
+
+
 class ServerBasicCancelTestCase(testcase.RabbitTestCase, unittest.TestCase):
     _multiprocess_can_split_ = True
 
+    def setUp(self):
+        super().setUp()
+        self.queue_name = str(uuid.uuid4())
+
     @testing.coroutine
     def test_cancel_whilst_consuming(self):
-        queue_name = 'queue_name'
-        yield from self.channel.queue_declare(queue_name)
+        yield from self.channel.queue_declare(self.queue_name)
 
         # None is non-callable.  We want to make sure the callback is
         # unregistered and never called.
         yield from self.channel.basic_consume(None)
-        yield from self.channel.queue_delete(queue_name)
+        yield from self.channel.queue_delete(self.queue_name)
+
+    @testing.coroutine
+    def test_cancel_callbacks(self):
+        callback_calls = []
+
+        @asyncio.coroutine
+        def coroutine_callback(*args, **kwargs):
+            callback_calls.append((args, kwargs))
+
+        def function_callback(*args, **kwargs):
+            callback_calls.append((args, kwargs))
+
+        self.channel.add_cancellation_callback(coroutine_callback)
+        self.channel.add_cancellation_callback(function_callback)
+
+        yield from self.channel.queue_declare(self.queue_name)
+        rv = yield from self.channel.basic_consume(consumer)
+        yield from self.channel.queue_delete(self.queue_name)
+
+        self.assertEqual(2, len(callback_calls))
+        for args, kwargs in callback_calls:
+            self.assertIs(self.channel, args[0])
+            self.assertEqual(rv['consumer_tag'], args[1])
+
+    @testing.coroutine
+    def test_cancel_callback_exceptions(self):
+        callback_calls = []
+
+        def function_callback(*args, **kwargs):
+            callback_calls.append((args, kwargs))
+            raise RuntimeError
+
+        self.channel.add_cancellation_callback(function_callback)
+        self.channel.add_cancellation_callback(function_callback)
+
+        yield from self.channel.queue_declare(self.queue_name)
+        yield from self.channel.basic_consume(consumer)
+        yield from self.channel.queue_delete(self.queue_name)
+
+        self.assertEqual(2, len(callback_calls))
+        self.assertTrue(self.channel.is_open)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -180,7 +180,33 @@ In the callback:
     app_id
     cluster_id
 
+Server Cancellation
+~~~~~~~~~~~~~~~~~~~
 
+RabbitMQ offers an AMQP extension to notify a consumer when a queue is deleted.
+See `Consumer Cancel Notification <https://www.rabbitmq.com/consumer-cancel.html>`_
+for additional details.  ``aioamqp`` enables the extension for all channels but
+takes no action when the consumer is cancelled.  Your application can be notified
+of consumer cancellations by adding a callback to the channel::
+
+    @asyncio.coroutine
+    def consumer_cancelled(channel, consumer_tag):
+        # implement required cleanup here
+        pass
+
+
+    @asyncio.coroutine
+    def consumer(channel, body, envelope, properties):
+        channel.basic_ack(envelope.delivery_tag)
+
+
+    channel = yield from protocol.channel()
+    channel.add_cancellation_callback(consumer_cancelled)
+    yield from channel.basic_consume(consumer, queue_name="my_queue")
+
+The callback can be a simple callable or an asynchronous co-routine.  It can
+be used to restart consumption on the channel, close the channel, or anything
+else that is appropriate for your application.
 
 Queues
 ------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Next release
 ------------
 
+ * Call user-specified callback when a consumer is cancelled.
+
 Aioamqp 0.11.0
 --------------
 


### PR DESCRIPTION
RabbitMQ has the concept of the broker sending a `basic.cancel` to the consumer when the queue that the consumer is connected to is deleted (see [Consumer Cancel Notification]).  `aioamqp` has direct support for receiving cancellations but no way to react to them.  The result is that cancelled consumers are simply never called again.

The PR adds a new method to the channel to register callbacks that are invoked when a channel receives a cancellation notification.  I considered invoking the error callback on the connection but that could lead to problems for projects that are currently using it.  Another alternative would be to add a similar error callback for the channel that is invoked with a specific exception when cancellation occurs.

I'm open to any of the alternatives.  This PR is one possible way to solve the problem.  Let me know if you want to approach this in some other way.

[Consumer Cancel Notification]: https://www.rabbitmq.com/consumer-cancel.html