### PR TITLE
Add check for bit length  used by frame int value to write long-long-int

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.5
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN pip install -r requirements_dev.txt

--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,12 @@ Tests require an instance of RabbitMQ. You can start a new instance using docker
 
 Then you can run the tests with ``make test`` (requires ``nose``).
 
+tests using docker-compose
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+Start RabbitMQ using ``docker-compose up -d rabbitmq``. When RabbitMQ has started, start the tests using ``docker-compose up --build aioamqp-test``
+
+
+
 
 .. _AMQP 0.9.1 protocol: https://www.rabbitmq.com/amqp-0-9-1-quickref.html
 .. _PEP 3156: http://www.python.org/dev/peps/pep-3156/

--- a/aioamqp/frame.py
+++ b/aioamqp/frame.py
@@ -92,8 +92,12 @@ class AmqpEncoder:
             self.payload.write(b'F')
             self.write_table(value)
         elif isinstance(value, int):
-            self.payload.write(b'I')
-            self.write_long(value)
+            if value.bit_length() >= 32:
+                self.payload.write(b'L')
+                self.write_long_long(value)
+            else:
+                self.payload.write(b'I')
+                self.write_long(value)
         elif isinstance(value, float):
             self.payload.write(b'd')
             self.write_float(value)

--- a/aioamqp/tests/test_connect.py
+++ b/aioamqp/tests/test_connect.py
@@ -13,7 +13,7 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_connect(self):
-        _transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop)
+        _transport, proto = yield from connect(host=self.host, port=self.port, virtualhost=self.vhost, loop=self.loop)
         self.assertEqual(proto.state, OPEN)
         self.assertIsNotNone(proto.server_properties)
         yield from proto.close()
@@ -25,6 +25,8 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
         channel_max = 10
         heartbeat = 100
         _transport, proto = yield from connect(
+            host=self.host,
+            port=self.port,
             virtualhost=self.vhost,
             loop=self.loop,
             channel_max=channel_max,
@@ -48,7 +50,7 @@ class AmqpConnectionTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_socket_nodelay(self):
-        transport, proto = yield from connect(virtualhost=self.vhost, loop=self.loop)
+        transport, proto = yield from connect(host=self.host, port=self.port, virtualhost=self.vhost, loop=self.loop)
         sock = transport.get_extra_info('socket')
         opt_val = sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
         self.assertNotEqual(opt_val, 0)

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -19,7 +19,7 @@ class ProtocolTestCase(testcase.RabbitTestCase, unittest.TestCase):
 
     @testing.coroutine
     def test_connect(self):
-        _transport, protocol = yield from amqp_connect(virtualhost=self.vhost, loop=self.loop)
+        _transport, protocol = yield from amqp_connect(host=self.host, port=self.port, virtualhost=self.vhost, loop=self.loop)
         self.assertEqual(protocol.state, OPEN)
         yield from protocol.close()
 
@@ -30,6 +30,8 @@ class ProtocolTestCase(testcase.RabbitTestCase, unittest.TestCase):
             'program_version': '0.1.1',
         }
         _transport, protocol = yield from amqp_connect(
+            host=self.host,
+            port=self.port,
             virtualhost=self.vhost,
             client_properties=client_properties,
             loop=self.loop,
@@ -41,11 +43,11 @@ class ProtocolTestCase(testcase.RabbitTestCase, unittest.TestCase):
     @testing.coroutine
     def test_connection_unexistant_vhost(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):
-            yield from amqp_connect(virtualhost='/unexistant', loop=self.loop)
+            yield from amqp_connect(host=self.host, port=self.port, virtualhost='/unexistant', loop=self.loop)
 
     def test_connection_wrong_login_password(self):
         with self.assertRaises(exceptions.AmqpClosedConnection):
-            self.loop.run_until_complete(amqp_connect(login='wrong', password='wrong', loop=self.loop))
+            self.loop.run_until_complete(amqp_connect(host=self.host, port=self.port, login='wrong', password='wrong', loop=self.loop))
 
     @testing.coroutine
     def test_connection_from_url(self):

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -51,6 +51,20 @@ class QueueDeclareTestCase(testcase.RabbitTestCase, unittest.TestCase):
         self.assertEqual(result['queue'].split('.')[-1], queue_name)
 
     @testing.coroutine
+    def test_queue_declare_custom_x_message_ttl_32_bits(self):
+        queue_name = 'queue_name'
+        # 2147483648 == 10000000000000000000000000000000
+        # in binary, meaning it is 32 bit long
+        x_message_ttl = 2147483648
+        result = yield from self.channel.queue_declare('queue_name', arguments={
+            'x-message-ttl': x_message_ttl
+        })
+        self.assertEqual(result['message_count'], 0)
+        self.assertEqual(result['consumer_count'], 0)
+        self.assertEqual(result['queue'].split('.')[-1], queue_name)
+        self.assertTrue(result)
+
+    @testing.coroutine
     def test_queue_declare_passive_nonexistant_queue(self):
         queue_name = 'queue_name'
         with self.assertRaises(exceptions.ChannelClosed) as cm:

--- a/aioamqp/tests/testcase.py
+++ b/aioamqp/tests/testcase.py
@@ -85,7 +85,7 @@ class RabbitTestCase(testing.AsyncioTestCaseMixin):
         self.port = os.environ.get('AMQP_PORT', 5672)
         self.vhost = os.environ.get('AMQP_VHOST', self.VHOST + str(uuid.uuid4()))
         self.http_client = pyrabbit.api.Client(
-            'localhost:15672/api/', 'guest', 'guest', timeout=20
+            '{HOST}:15672/api/'.format(HOST=self.host), 'guest', 'guest', timeout=20
         )
 
         self.amqps = []

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3'
+services:
+  aioamqp-test:
+    build: .
+    command: ["make", "test"]
+    depends_on:
+      - rabbitmq
+    environment:
+      - AMQP_HOST=rabbitmq
+  rabbitmq:
+    hostname: rabbitmq
+    image: rabbitmq:3-management
+    environment:
+      - RABBITMQ_NODENAME=my-rabbit
+    ports:
+      - 15672
+      - 5672


### PR DESCRIPTION
This fixes #180 using [bit_length](https://docs.python.org/3/library/stdtypes.html#int.bit_length) to check if the value needs to be a `long-long-int`