### PR TITLE
WIP raise exception on unsupported auth method WIP

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -187,8 +187,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         """
 
         if login_method != 'PLAIN':
-            # TODO
-            logger.warning('only PLAIN login_method is supported, falling back to AMQPLAIN')
+            raise exceptions.AioamqpException('only PLAIN login_method is supported')
 
         self._stream_writer.write(amqp_constants.PROTOCOL_HEADER)
 


### PR DESCRIPTION
This could work but we need to resolve the following inconsistency:
- https://github.com/Polyconseil/aioamqp/blob/master/aioamqp/__init__.py#L13
- https://github.com/Polyconseil/aioamqp/blob/master/aioamqp/protocol.py#L189

(`AMQPLAIN` vs `PLAIN`) and fix the test failures