### PR TITLE
Check connection is open

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -147,6 +147,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             # drain() cannot be called concurrently by multiple coroutines:
             # http://bugs.python.org/issue29930. Remove this lock when no
             # version of Python where this bugs exists is supported anymore.
+            await self.ensure_open()
             await self._stream_writer.drain()
 
     async def _write_frame(self, channel_id, request, drain=True):


### PR DESCRIPTION
Sometimes, i see in logs error: ` type=<class 'AttributeError'>, error='NoneType' object has no attribute 'drain'`  after `channel.basic_publish`. It is vary hard for reproduce.