### PR TITLE
Rename message property `type` to `message_type`

### DIFF
--- a/aioamqp/constants.py
+++ b/aioamqp/constants.py
@@ -92,8 +92,10 @@ TX_ROLLBACK_OK = 31
 CONFIRM_SELECT = 10
 CONFIRM_SELECT_OK = 11
 
-MESSAGE_PROPERTIES = ('content_type', 'content_encoding', 'headers', 'delivery_mode', 'priority', 'correlation_id',
-                      'reply_to', 'expiration', 'message_id', 'timestamp', 'type', 'user_id', 'app_id', 'cluster_id')
+MESSAGE_PROPERTIES = (
+    'content_type', 'content_encoding', 'headers', 'delivery_mode', 'priority', 'correlation_id',
+    'reply_to', 'expiration', 'message_id', 'timestamp', 'message_type', 'user_id', 'app_id', 'cluster_id',
+)
 
 FLAG_CONTENT_TYPE = (1 << 15)
 FLAG_CONTENT_ENCODING = (1 << 14)

--- a/aioamqp/properties.py
+++ b/aioamqp/properties.py
@@ -9,7 +9,7 @@ class Properties:
     def __init__(
             self, content_type=None, content_encoding=None, headers=None, delivery_mode=None,
             priority=None, correlation_id=None, reply_to=None, expiration=None, message_id=None,
-            timestamp=None, type=None, user_id=None, app_id=None, cluster_id=None): # pylint: disable=redefined-builtin
+            timestamp=None, message_type=None, user_id=None, app_id=None, cluster_id=None):
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
@@ -20,7 +20,7 @@ class Properties:
         self.expiration = expiration
         self.message_id = message_id
         self.timestamp = timestamp
-        self.type = type
+        self.message_type = message_type
         self.user_id = user_id
         self.app_id = app_id
         self.cluster_id = cluster_id
@@ -38,7 +38,7 @@ def from_pamqp(instance):
     props.expiration = instance.expiration
     props.message_id = instance.message_id
     props.timestamp = instance.timestamp
-    props.type = instance.message_type
+    props.message_type = instance.message_type
     props.user_id = instance.user_id
     props.app_id = instance.app_id
     props.cluster_id = instance.cluster_id

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -159,7 +159,7 @@ In the callback:
     routing_key
     is_redeliver
 
-* the ``properties`` are message properties, an instance of properties.Properties with the following members::
+* the ``properties`` are message properties, an instance of ``properties.Properties`` with the following members::
 
     content_type
     content_encoding
@@ -171,7 +171,7 @@ In the callback:
     expiration
     message_id
     timestamp
-    type
+    message_type
     user_id
     app_id
     cluster_id

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Next release
 ------------
 
+ * Rename ``type`` to ``message_type`` in constant.Properties object to be full compatible with pamqp.
+
 Aioamqp 0.13.0
 --------------
 


### PR DESCRIPTION
Since the migration to `pamqp` we had an incompatiblity with the `message_type` attribute, described here https://github.com/Polyconseil/aioamqp/issues/201

We now rename the `type` attribute to `message_type`.

the next part is to use the properties object in `publish` methods.