### PR TITLE
Fixed problem of multiple consuming cancel in the same time

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -563,14 +563,14 @@ class Channel:
     async def basic_cancel(self, consumer_tag, no_wait=False):
         request = pamqp.specification.Basic.Cancel(consumer_tag, no_wait)
         return (await self._write_frame_awaiting_response(
-            'basic_cancel', self.channel_id, request, no_wait=no_wait)
+            'basic_cancel' + consumer_tag, self.channel_id, request, no_wait=no_wait)
         )
 
     async def basic_cancel_ok(self, frame):
         results = {
             'consumer_tag': frame.consumer_tag,
         }
-        future = self._get_waiter('basic_cancel')
+        future = self._get_waiter('basic_cancel' + frame.consumer_tag)
         future.set_result(results)
         logger.debug("Cancel ok")
 


### PR DESCRIPTION
How to reproduce problem.

1. Open 2 queue to consuming
2. Close them in the same time
3. Catch "aioamqp.exceptions.SynchronizationError: Waiter already exists"
