### PR TITLE
Separate waiters for 'basic_cancel'

### DIFF
--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -563,14 +563,14 @@ class Channel:
     async def basic_cancel(self, consumer_tag, no_wait=False):
         request = pamqp.specification.Basic.Cancel(consumer_tag, no_wait)
         return (await self._write_frame_awaiting_response(
-            'basic_cancel', self.channel_id, request, no_wait=no_wait)
+            'basic_cancel' + consumer_tag, self.channel_id, request, no_wait=no_wait)
         )
 
     async def basic_cancel_ok(self, frame):
         results = {
             'consumer_tag': frame.consumer_tag,
         }
-        future = self._get_waiter('basic_cancel')
+        future = self._get_waiter('basic_cancel' + frame.consumer_tag)
         future.set_result(results)
         logger.debug("Cancel ok")
 

--- a/aioamqp/tests/test_consume.py
+++ b/aioamqp/tests/test_consume.py
@@ -115,6 +115,10 @@ class ConsumeTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
         self.assertEqual(b"coucou2", body2)
         self.assertIsInstance(properties2, Properties)
 
+        # close consuming
+        await asyncio.gather(self.channel.basic_cancel(ctag_q1),
+                             self.channel.basic_cancel(ctag_q2))
+
     async def test_duplicate_consumer_tag(self):
         await self.channel.queue_declare("q1", exclusive=True, no_wait=False)
         await self.channel.queue_declare("q2", exclusive=True, no_wait=False)


### PR DESCRIPTION
How to reproduce problem.

1. Open 2 queue to consuming
2. Close them in the same time
2. Catch "aioamqp.exceptions.SynchronizationError: Waiter already exists"