### PR TITLE
Do not send and do not expect heartbeat if hearbeat value is 0

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -347,7 +347,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         self._stream_writer.close()
 
     def _heartbeat_timer_recv_reset(self):
-        if self.server_heartbeat is None:
+        if self.server_heartbeat is None or self.server_heartbeat == 0:
             return
         if self._heartbeat_timer_recv is not None:
             self._heartbeat_timer_recv.cancel()
@@ -356,7 +356,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             self._heartbeat_timer_recv_timeout)
 
     def _heartbeat_timer_send_reset(self):
-        if self.server_heartbeat is None:
+        if self.server_heartbeat is None or self.server_heartbeat == 0:
             return
         if self._heartbeat_timer_send is not None:
             self._heartbeat_timer_send.cancel()


### PR DESCRIPTION
If heartbeat is not set, open channel fails when using older RabbitMQ (or if RabbitMQ configured not to use heartbeat)