### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - 3.5
 - 3.6
 - 3.7-dev
+- 3.8
 services:
 - rabbitmq
 env:

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -65,7 +65,8 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             client_properties: dict, client-props to tune the client identification
         """
         self._loop = kwargs.get('loop') or asyncio.get_event_loop()
-        super().__init__(asyncio.StreamReader(loop=self._loop), loop=self._loop)
+        self._reader = asyncio.StreamReader(loop=self._loop)
+        super().__init__(self._reader, loop=self._loop)
         self._on_error_callback = kwargs.get('on_error')
 
         self.client_properties = kwargs.get('client_properties', {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py35.py36.py37
+python-tag = py35.py36.py37.py38

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     platforms='all',
     license='BSD'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37
+envlist = py35, py36, py37, py38
 skipsdist = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
In python 3.8 the `StreamReader` within the `StreamReaderProtocol` has been changed to a `weakref`.
We have to keep a strong ref to the `StreamReader` in scope for the lifetime of the `AmqpProtocol`.

Polyconseil/aioamqp#210