### PR TITLE
Fix broken test test_wrong_parameter_queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: bionic
 python:
 - 3.5
 - 3.6

--- a/aioamqp/tests/test_queue.py
+++ b/aioamqp/tests/test_queue.py
@@ -72,7 +72,7 @@ class QueueDeclareTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
             await self.channel.queue_declare(queue_name,
                 passive=False, exclusive=True, auto_delete=True)
 
-        self.assertEqual(cm.exception.code, 406)
+        self.assertIn(cm.exception.code, [405, 406])
 
     async def test_multiple_channel_same_queue(self):
         queue_name = 'queue_name'


### PR DESCRIPTION
Changed the expected error code to 405 or 406 (depends on the rabbitmq version)

The test was broken due to a rabbitmq change: rabbitmq/rabbitmq-server#1888
The exclusiveness check (which generates a 405) has been moved to before the argument equality check (which generates a 406).

Additionally fixed the travis build by changing to bionic. There is a bug in the latest rabbitmq version available on xenial that was being hit by `test_queue_declare_custom_x_message_ttl_32_bits`. The bug has been fixed in the version available on bionic.