### PR TITLE
support amqps:// to enable SSL connection

### DIFF
--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
 import socket
+from ssl import create_default_context
 from urllib.parse import urlparse
 
 from .exceptions import *  # pylint: disable=wildcard-import
@@ -89,6 +90,9 @@ async def from_url(
 
     if url.scheme not in ('amqp', 'amqps'):
         raise ValueError('Invalid protocol %s, valid protocols are amqp or amqps' % url.scheme)
+
+    if url.scheme == 'amqps' and not kwargs.get('ssl'):
+        kwargs['ssl'] = create_default_context()
 
     transport, protocol = await connect(
         host=url.hostname or 'localhost',

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -84,6 +84,28 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
                 loop=self.loop,
             )
 
+    async def test_amqps_connection_from_url(self):
+        ssl_context = mock.Mock()
+        with mock.patch('aioamqp.create_default_context') as create_default_context:
+            with mock.patch('aioamqp.connect') as connect:
+                create_default_context.return_value = ssl_context
+                async def func(*x, **y):
+                    return 1, 2
+                connect.side_effect = func
+                await amqp_from_url('amqps://tom:pass@example.com:7777/myvhost', loop=self.loop)
+                connect.assert_called_once_with(
+                    insist=False,
+                    password='pass',
+                    login_method='AMQPLAIN',
+                    ssl=ssl_context,
+                    login='tom',
+                    host='example.com',
+                    protocol_factory=AmqpProtocol,
+                    virtualhost='myvhost',
+                    port=7777,
+                    loop=self.loop
+                )
+
     async def test_from_url_raises_on_wrong_scheme(self):
         with self.assertRaises(ValueError):
             await amqp_from_url('invalid://')


### PR DESCRIPTION
from_url() treat amqps as a valid scheme, but it doesn't set ssl argument.
This becomes inconvenient when you want to enable SSL via URL parameter.

This PR will check for amqps:// scheme and set ssl argument with default SSL context when ssl argument is not specified explicitly.

Added UT to verify ssl works in both situation.