### PR TITLE
Use PLAIN auth method as others are not supported

### DIFF
--- a/aioamqp/__init__.py
+++ b/aioamqp/__init__.py
@@ -10,7 +10,7 @@ from .version import __packagename__
 
 
 async def connect(host='localhost', port=None, login='guest', password='guest',
-            virtualhost='/', ssl=None, login_method='AMQPLAIN', insist=False,
+            virtualhost='/', ssl=None, login_method='PLAIN', insist=False,
             protocol_factory=AmqpProtocol, *, loop=None, **kwargs):
     """Convenient method to connect to an AMQP broker
 
@@ -69,7 +69,7 @@ async def connect(host='localhost', port=None, login='guest', password='guest',
 
 
 async def from_url(
-        url, login_method='AMQPLAIN', insist=False, protocol_factory=AmqpProtocol, **kwargs):
+        url, login_method='PLAIN', insist=False, protocol_factory=AmqpProtocol, **kwargs):
     """ Connect to the AMQP using a single url parameter and return the client.
 
         For instance:

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -188,7 +188,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         """
 
         if login_method != 'PLAIN':
-            logger.warning('only PLAIN login_method is supported, falling back to AMQPLAIN')
+            logger.warning('login_method %s is not supported, falling back to PLAIN', login_method)
 
         self._stream_writer.write(amqp_constants.PROTOCOL_HEADER)
 

--- a/aioamqp/tests/test_protocol.py
+++ b/aioamqp/tests/test_protocol.py
@@ -55,7 +55,7 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
             connect.assert_called_once_with(
                 insist=False,
                 password='pass',
-                login_method='AMQPLAIN',
+                login_method='PLAIN',
                 login='tom',
                 host='example.com',
                 protocol_factory=AmqpProtocol,
@@ -74,7 +74,7 @@ class ProtocolTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
             connect.assert_called_once_with(
                 insist=False,
                 password='pass',
-                login_method='AMQPLAIN',
+                login_method='PLAIN',
                 ssl=ssl_context,
                 login='tom',
                 host='example.com',


### PR DESCRIPTION
fixes the anoying warning message as we changed the login method
when we switched to pamqp.