### PR TITLE
protocol: cleanly stop the run() task

### DIFF
--- a/aioamqp/tests/test_connection_close.py
+++ b/aioamqp/tests/test_connection_close.py
@@ -22,7 +22,7 @@ class CloseTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
             # TODO: remove with python <3.4.4 support
             self.assertTrue(transport._closing)
         # make sure those 2 tasks/futures are properly set as finished
-        await amqp.stop_now
+        await amqp.stop_now.wait()
         await amqp.worker
 
     async def test_multiple_close(self):


### PR DESCRIPTION
We kept the run() task running forever, even if the connection was closed cleanly.
This commit also use an Event instead of a Future.