### PR TITLE
Introduce a new api to consume message from Rabbit.

### DIFF
--- a/examples/receive.py
+++ b/examples/receive.py
@@ -7,16 +7,18 @@ import asyncio
 import aioamqp
 
 
-async def callback(channel, body, envelope, properties):
-    print(" [x] Received %r" % body)
-
 async def receive():
     transport, protocol = await aioamqp.connect()
     channel = await protocol.channel()
 
     await channel.queue_declare(queue_name='hello')
 
-    await channel.basic_consume(callback, queue_name='hello')
+    x = channel.consume(queue_name='hello')
+    await x.qos(prefetch_size=0, prefetch_count=1)
+    async with x as consumer:
+        async for message in consumer:
+            body, envelope, properties = message
+            await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
 
 
 event_loop = asyncio.get_event_loop()


### PR DESCRIPTION
The goal is to get rid of the callback, which is imho a non-sense
in an asyncio context.

the new Channel::consume method now returns a MessageQueue objects
which can be iterated using async for.

This object allows us to ease the API:

```python
    x = channel.consume(queue_name='hello')
    await x.qos(prefetch_size=0, prefetch_count=1)
    async with x as consumer:
        async for message in consumer:
            body, envelope, properties = message
            await channel.basic_client_ack(delivery_tag=envelope.delivery_tag)
```