### PR TITLE
Add Python 3.9 support + drop Python 3.5 + CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
-dist: bionic
+dist: focal
 python:
-- 3.5
 - 3.6
-- 3.7-dev
+- 3.7
 - 3.8
+- 3.9
 services:
 - rabbitmq
 env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.9
 
 WORKDIR /usr/src/app
 

--- a/aioamqp/channel.py
+++ b/aioamqp/channel.py
@@ -31,7 +31,7 @@ class Channel:
         self.cancellation_callbacks = []
         self.return_callback = return_callback
         self.response_future = None
-        self.close_event = asyncio.Event(loop=self._loop)
+        self.close_event = asyncio.Event()
         self.cancelled_consumers = set()
         self.last_consumer_tag = None
         self.publisher_confirms = False
@@ -518,7 +518,7 @@ class Channel:
         }
         future = self._get_waiter('basic_consume' + ctag)
         future.set_result(results)
-        self._ctag_events[ctag] = asyncio.Event(loop=self._loop)
+        self._ctag_events[ctag] = asyncio.Event()
 
     async def basic_deliver(self, frame):
         consumer_tag = frame.consumer_tag

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -456,11 +456,11 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         await self.ensure_open()
         try:
             channel_id = self.channels_ids_free.pop()
-        except KeyError:
+        except KeyError as ex:
             assert self.server_channel_max is not None, 'connection channel-max tuning not performed'
             # channel-max = 0 means no limit
             if self.server_channel_max and self.channels_ids_ceil > self.server_channel_max:
-                raise exceptions.NoChannelAvailable()
+                raise exceptions.NoChannelAvailable() from ex
             self.channels_ids_ceil += 1
             channel_id = self.channels_ids_ceil
         channel = self.CHANNEL_FACTORY(self, channel_id, **kwargs)

--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -79,7 +79,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             self.connection_tunning['heartbeat'] = kwargs.get('heartbeat')
 
         self.connecting = asyncio.Future(loop=self._loop)
-        self.connection_closed = asyncio.Event(loop=self._loop)
+        self.connection_closed = asyncio.Event()
         self.stop_now = asyncio.Future(loop=self._loop)
         self.state = CONNECTING
         self.version_major = None
@@ -91,14 +91,14 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
         self.server_heartbeat = None
         self._heartbeat_timer_recv = None
         self._heartbeat_timer_send = None
-        self._heartbeat_trigger_send = asyncio.Event(loop=self._loop)
+        self._heartbeat_trigger_send = asyncio.Event()
         self._heartbeat_worker = None
         self.channels = {}
         self.server_frame_max = None
         self.server_channel_max = None
         self.channels_ids_ceil = 0
         self.channels_ids_free = set()
-        self._drain_lock = asyncio.Lock(loop=self._loop)
+        self._drain_lock = asyncio.Lock()
 
     def connection_made(self, transport):
         super().connection_made(transport)
@@ -171,10 +171,10 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             await self.wait_closed(timeout=timeout)
 
     async def wait_closed(self, timeout=None):
-        await asyncio.wait_for(self.connection_closed.wait(), timeout=timeout, loop=self._loop)
+        await asyncio.wait_for(self.connection_closed.wait(), timeout=timeout)
         if self._heartbeat_worker is not None:
             try:
-                await asyncio.wait_for(self._heartbeat_worker, timeout=timeout, loop=self._loop)
+                await asyncio.wait_for(self._heartbeat_worker, timeout=timeout)
             except asyncio.CancelledError:
                 pass
 

--- a/aioamqp/tests/test_basic.py
+++ b/aioamqp/tests/test_basic.py
@@ -58,7 +58,7 @@ class BasicCancelTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
 
         result = await self.channel.publish("payload", exchange_name, routing_key='')
 
-        await asyncio.sleep(5, loop=self.loop)
+        await asyncio.sleep(5)
 
         result = await self.channel.queue_declare(queue_name, passive=True)
         self.assertEqual(result['message_count'], 1)

--- a/aioamqp/tests/test_connection_lost.py
+++ b/aioamqp/tests/test_connection_lost.py
@@ -24,7 +24,7 @@ class ConnectionLostTestCase(testcase.RabbitTestCaseMixin, asynctest.TestCase):
         self.assertEqual(amqp.state, OPEN)
         self.assertTrue(channel.is_open)
         amqp._stream_reader._transport.close()  # this should have the same effect as the tcp connection being lost
-        await asyncio.wait_for(amqp.worker, 1, loop=self.loop)
+        await asyncio.wait_for(amqp.worker, 1)
         self.assertEqual(amqp.state, CLOSED)
         self.assertFalse(channel.is_open)
         self.assertTrue(self.callback_called)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,8 @@ Changelog
 Next release
 ------------
 
+ * Add support for Python 3.9.
+ * Drop support for Python 3.5.
  * Fix annoying auth method warning because of a wrong defined default argument (closes #214).
 
 Aioamqp 0.14.0

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -7,7 +7,7 @@ Aioamqp library is a pure-Python implementation of the AMQP 0.9.1 protocol using
 Prerequisites
 -------------
 
-Aioamqp works only with python >= 3.5 using asyncio library.
+Aioamqp works only with python >= 3.6 using asyncio library.
 
 Installation
 ------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py35.py36.py37.py38
+python-tag = py36.py37.py38.py39

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,10 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     platforms='all',
     license='BSD'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38, py39
 skipsdist = true
 skip_missing_interpreters = true
 


### PR DESCRIPTION
* Use newer Ubuntu in CI. This provides more recent RabbitMQ version.
* Add support for Python 3.9. Add to CI.
* Fix deprecation warnings for asyncio: explicit passing of loop is deprecated for some functions as of Python 3.8.
* Drop support for Python 3.5 as it is end-of-life.
