### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: python
 dist: focal
+arch:
+- amd64
+- ppc64le
 python:
 - 3.6
 - 3.7
 - 3.8
 - 3.9
+jobs:
+ exclude:
+  - arch: ppc64le
+    python: 3.7
 services:
 - rabbitmq
 env:


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. Since ppc64le focal doesn't have python 3.7 support, that is only excluded.