### PR TITLE
Fix arguments to error callback on non-coroutines

### DIFF
--- a/aioamqp/protocol.py
+++ b/aioamqp/protocol.py
@@ -305,7 +305,7 @@ class AmqpProtocol(asyncio.StreamReaderProtocol):
             if asyncio.iscoroutinefunction(self._on_error_callback):
                 asyncio.ensure_future(self._on_error_callback(exception), loop=self._loop)
             else:
-                self._on_error_callback(exceptions.ChannelClosed(exception))
+                self._on_error_callback(exception)
 
         for channel in self.channels.values():
             channel.connection_closed(reply_code, reply_text, exception)


### PR DESCRIPTION
The error callback was previously given different parameters when `asyncio.iscoroutinefunction(self._on_error_callback)` is true/false.